### PR TITLE
Minor FunctionGraph Updates and Misc

### DIFF
--- a/aesara/__init__.py
+++ b/aesara/__init__.py
@@ -91,6 +91,7 @@ from aesara.compile import (
 from aesara.compile.function import function, function_dump
 from aesara.compile.function.types import FunctionMaker
 from aesara.gradient import Lop, Rop, grad, subgraph_grad
+from aesara.printing import debugprint as dprint
 from aesara.printing import pp, pprint
 from aesara.updates import OrderedUpdates
 

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -1,7 +1,6 @@
 """A container for specifying and manipulating a graph with distinct inputs and outputs."""
 import time
 from collections import OrderedDict
-from io import StringIO
 
 import aesara
 from aesara.configdefaults import config
@@ -475,40 +474,7 @@ class FunctionGraph(utils.MetaObject):
         if verbose:
             print(reason, var, new_var)
 
-        if var.type != new_var.type:
-            new_var_2 = var.type.convert_variable(new_var)
-            # We still make sure that the type converts correctly
-            if new_var_2 is None or new_var_2.type != var.type:
-                done = dict()
-                used_ids = dict()
-                old = aesara.compile.debugmode.debugprint(
-                    var,
-                    prefix="  ",
-                    depth=6,
-                    file=StringIO(),
-                    done=done,
-                    print_type=True,
-                    used_ids=used_ids,
-                ).getvalue()
-                new = aesara.compile.debugmode.debugprint(
-                    new_var,
-                    prefix="  ",
-                    depth=6,
-                    file=StringIO(),
-                    done=done,
-                    print_type=True,
-                    used_ids=used_ids,
-                ).getvalue()
-                raise toolbox.BadOptimization(
-                    var,
-                    new_var,
-                    None,
-                    None,
-                    str(reason) + ". The type of the replacement must be the same.",
-                    old,
-                    new,
-                )
-            new_var = new_var_2
+        new_var = var.type.filter_variable(new_var, allow_convert=True)
 
         if var not in self.variables:
             # this variable isn't in the graph... don't raise an

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -137,8 +137,7 @@ class FunctionGraph(utils.MetaObject):
         # outputs even if they aren't used in the graph.
         self.variables = set()
 
-        # TODO FIXME: We should *not* be using a list created elsewhere!
-        self.outputs = outputs
+        self.outputs = list(outputs)
         self.clients = {}
 
         for f in features:

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -856,9 +856,9 @@ class MergeOptimizer(GlobalOptimizer):
                     # Only need to check one of the var of each pairs.
                     # If it is a Constant, the other must also be a Constant as we merge them.
                     if all([isinstance(old, Constant) for old, new in pairs]):
-                        fgraph.replace_all(pairs, "MergeOptimizer")
+                        fgraph.replace_all(pairs, reason="MergeOptimizer")
                     else:
-                        fgraph.replace_all_validate(pairs, "MergeOptimizer")
+                        fgraph.replace_all_validate(pairs, reason="MergeOptimizer")
                 except InconsistencyError:
                     success = False
                     nb_fail += 1

--- a/aesara/graph/toolbox.py
+++ b/aesara/graph/toolbox.py
@@ -555,10 +555,12 @@ class ReplaceValidate(History, Validator):
         del fgraph.replace_all_validate
         del fgraph.replace_all_validate_remove
 
-    def replace_validate(self, fgraph, r, new_r, reason=None):
-        self.replace_all_validate(fgraph, [(r, new_r)], reason=reason)
+    def replace_validate(self, fgraph, r, new_r, reason=None, **kwargs):
+        self.replace_all_validate(fgraph, [(r, new_r)], reason=reason, **kwargs)
 
-    def replace_all_validate(self, fgraph, replacements, reason=None, verbose=None):
+    def replace_all_validate(
+        self, fgraph, replacements, reason=None, verbose=None, **kwargs
+    ):
         chk = fgraph.checkpoint()
         if verbose is None:
             verbose = config.optimizer_verbose
@@ -569,7 +571,7 @@ class ReplaceValidate(History, Validator):
 
         for r, new_r in replacements:
             try:
-                fgraph.replace(r, new_r, reason=reason, verbose=False)
+                fgraph.replace(r, new_r, reason=reason, verbose=False, **kwargs)
             except Exception as e:
                 msg = str(e)
                 s1 = "The type of the replacement must be the same"
@@ -630,14 +632,14 @@ class ReplaceValidate(History, Validator):
         return chk
 
     def replace_all_validate_remove(
-        self, fgraph, replacements, remove, reason=None, warn=True
+        self, fgraph, replacements, remove, reason=None, warn=True, **kwargs
     ):
         """
         As replace_all_validate, revert the replacement if the ops
         in the list remove are still in the graph. Also print a warning.
 
         """
-        chk = fgraph.replace_all_validate(replacements, reason)
+        chk = fgraph.replace_all_validate(replacements, reason=reason, **kwargs)
         self._nodes_removed.update(remove)
         for rm in remove:
             if rm in fgraph.apply_nodes or rm in fgraph.variables:

--- a/aesara/graph/toolbox.py
+++ b/aesara/graph/toolbox.py
@@ -821,7 +821,7 @@ def is_same_graph_with_merge(var1, var2, givens=None):
     # which happens when the graph is made of a single Variable.
     # We also need to make sure we replace a Variable if it is present in
     # `givens`.
-    vars_replaced = [givens.get(v, v) for v in vars]
+    vars_replaced = [givens.get(v, v) for v in fgraph.outputs]
     o1, o2 = [v.owner for v in vars_replaced]
     if o1 is None and o2 is None:
         # Comparing two single-Variable graphs: they are equal if they are

--- a/aesara/graph/toolbox.py
+++ b/aesara/graph/toolbox.py
@@ -337,7 +337,7 @@ class GetCheckpoint:
         return self.nb
 
 
-class LambdExtract:
+class LambdaExtract:
     def __init__(self, fgraph, node, i, r, reason=None):
         self.fgraph = fgraph
         self.node = node
@@ -395,7 +395,7 @@ class History(Feature):
         if self.history[fgraph] is None:
             return
         h = self.history[fgraph]
-        h.append(LambdExtract(fgraph, node, i, r, reason))
+        h.append(LambdaExtract(fgraph, node, i, r, reason))
 
     def revert(self, fgraph, checkpoint):
         """

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import numpy as np
 
@@ -56,7 +55,7 @@ class TensorType(CType):
     Inf entries. (Used in `DebugMode`)
     """
 
-    def __init__(self, dtype, broadcastable, name=None, sparse_grad=False):
+    def __init__(self, dtype, broadcastable, name=None):
         self.dtype = str(dtype)
         if self.dtype == "floatX":
             self.dtype = config.floatX
@@ -66,14 +65,6 @@ class TensorType(CType):
         self.dtype_specs()  # error checking is done there
         self.name = name
         self.numpy_dtype = np.dtype(self.dtype)
-        self.sparse_grad = sparse_grad
-        if sparse_grad:
-            warnings.warn(
-                "You use an old interface to"
-                " AdvancedSubtensor1 sparse_grad. Now use"
-                " aesara.sparse.sparse_grad(a_tensor[an_int_vector]).",
-                category=DeprecationWarning,
-            )
 
     def clone(self, dtype=None, broadcastable=None):
         """
@@ -85,9 +76,7 @@ class TensorType(CType):
             dtype = self.dtype
         if broadcastable is None:
             broadcastable = self.broadcastable
-        return self.__class__(
-            dtype, broadcastable, name=self.name, sparse_grad=self.sparse_grad
-        )
+        return self.__class__(dtype, broadcastable, name=self.name)
 
     def filter(self, data, strict=False, allow_downcast=None):
         """

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -24,6 +24,25 @@ all_dtypes = list(map(str, aes.all_types))
 int_dtypes = list(map(str, aes.int_types))
 uint_dtypes = list(map(str, aes.uint_types))
 
+# TODO: add more type correspondances for e.g. int32, int64, float32,
+# complex64, etc.
+dtype_specs_map = {
+    "float16": (float, "npy_float16", "NPY_FLOAT16"),
+    "float32": (float, "npy_float32", "NPY_FLOAT32"),
+    "float64": (float, "npy_float64", "NPY_FLOAT64"),
+    "bool": (bool, "npy_bool", "NPY_BOOL"),
+    "uint8": (int, "npy_uint8", "NPY_UINT8"),
+    "int8": (int, "npy_int8", "NPY_INT8"),
+    "uint16": (int, "npy_uint16", "NPY_UINT16"),
+    "int16": (int, "npy_int16", "NPY_INT16"),
+    "uint32": (int, "npy_uint32", "NPY_UINT32"),
+    "int32": (int, "npy_int32", "NPY_INT32"),
+    "uint64": (int, "npy_uint64", "NPY_UINT64"),
+    "int64": (int, "npy_int64", "NPY_INT64"),
+    "complex128": (complex, "aesara_complex128", "NPY_COMPLEX128"),
+    "complex64": (complex, "aesara_complex64", "NPY_COMPLEX64"),
+}
+
 
 class TensorType(CType):
     """
@@ -260,25 +279,8 @@ class TensorType(CType):
         This function is used internally as part of C code generation.
 
         """
-        # TODO: add more type correspondances for e.g. int32, int64, float32,
-        # complex64, etc.
         try:
-            return {
-                "float16": (float, "npy_float16", "NPY_FLOAT16"),
-                "float32": (float, "npy_float32", "NPY_FLOAT32"),
-                "float64": (float, "npy_float64", "NPY_FLOAT64"),
-                "bool": (bool, "npy_bool", "NPY_BOOL"),
-                "uint8": (int, "npy_uint8", "NPY_UINT8"),
-                "int8": (int, "npy_int8", "NPY_INT8"),
-                "uint16": (int, "npy_uint16", "NPY_UINT16"),
-                "int16": (int, "npy_int16", "NPY_INT16"),
-                "uint32": (int, "npy_uint32", "NPY_UINT32"),
-                "int32": (int, "npy_int32", "NPY_INT32"),
-                "uint64": (int, "npy_uint64", "NPY_UINT64"),
-                "int64": (int, "npy_int64", "NPY_INT64"),
-                "complex128": (complex, "aesara_complex128", "NPY_COMPLEX128"),
-                "complex64": (complex, "aesara_complex64", "NPY_COMPLEX64"),
-            }[self.dtype]
+            return dtype_specs_map[self.dtype]
         except KeyError:
             raise TypeError(
                 f"Unsupported dtype for {self.__class__.__name__}: {self.dtype}"

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -5,7 +5,6 @@ import pytest
 
 from aesara.configdefaults import config
 from aesara.graph.fg import FunctionGraph, MissingInputError
-from aesara.graph.toolbox import BadOptimization
 from tests.graph.utils import MyVariable, MyVariable2, op1, op2, op3
 
 
@@ -216,7 +215,7 @@ class TestFunctionGraph:
         var5 = op3(var4, var2, var2)
         fg = FunctionGraph([var1, var2], [var3, var5], clone=False)
 
-        with pytest.raises(BadOptimization):
+        with pytest.raises(TypeError):
             var0 = MyVariable2("var0")
             # The types don't match and one cannot be converted to the other
             fg.replace(var3, var0)


### PR DESCRIPTION
This PR makes some minor updates to `FunctionGraph` (e.g. make a copy of the `outputs` list argument, add a new option to import missing input variables), as well as a few other minor refactoring/clean-up changes.

This PR also exposes `aesara.printing.debugprint` at `aesara` package scope as `dprint`.  In other words, `debugprint` is now available as `aesara.dprint`.