### PR TITLE
Simplify the constant folding API

### DIFF
--- a/aesara/gpuarray/elemwise.py
+++ b/aesara/gpuarray/elemwise.py
@@ -414,9 +414,11 @@ class GpuElemwise(_NoPythonOp, HideC, Elemwise):
 
         return str(code)
 
-    # Since we don't have a perform ...
-    def python_constant_folding(self, node):
-        return False
+    def prepare_node(self, node, storage_map, compute_map, no_recycling, impl=None):
+        # Since we don't have a Python implementation, ignore `impl` and use C.
+        return super().prepare_node(
+            node, storage_map, compute_map, no_recycling, impl="c"
+        )
 
     def c_code_cache_version(self):
         ver = self.scalar_op.c_code_cache_version()

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -4346,18 +4346,12 @@ def constant_folding(fgraph, node):
     for o in node.outputs:
         storage_map[o] = [None]
         compute_map[o] = [False]
-    impl = None
-    if hasattr(node.op, "python_constant_folding") and node.op.python_constant_folding(
-        node
-    ):
-        impl = "py"
-    thunk = node.op.make_thunk(
-        node, storage_map, compute_map, no_recycling=[], impl=impl
-    )
 
+    thunk = node.op.make_thunk(node, storage_map, compute_map, no_recycling=[])
     required = thunk()
-    assert not required  # a node whose inputs are all provided should always
-    # return successfully
+    # A node whose inputs are all provided should always return successfully
+    assert not required
+
     rval = []
     for output in node.outputs:
         assert compute_map[output][0], (output, storage_map[output][0])

--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -665,6 +665,9 @@ second dimension
         # - NumPy ufunc support only up to 31 inputs.
         #   But our c code support more.
         # - nfunc is reused for scipy and scipy is optional
+        if len(node.inputs) > 32 and self.ufunc and impl == "py":
+            impl = "c"
+
         if getattr(self, "nfunc_spec", None) and impl != "c":
             self.nfunc = getattr(np, self.nfunc_spec[0], None)
             if self.nfunc is None:
@@ -1254,14 +1257,6 @@ second dimension
             return tuple(version)
         else:
             return ()
-
-    def python_constant_folding(self, node):
-        """
-        Return True if we do not want to compile c code
-        when doing constant folding of this node.
-        """
-        # The python code don't support 32 inputs or more.
-        return node.outputs[0].ndim == 0 and len(node.inputs) < 32
 
 
 class CAReduce(COp):

--- a/doc/extending/cop.txt
+++ b/doc/extending/cop.txt
@@ -209,20 +209,6 @@ There are less methods to define for a `COp` than for a `Type`:
        Overrides :meth:`c_code_cache_version` if defined, but
        otherwise has the same contract.
 
-    .. method:: python_constant_folding(node)
-
-       Optional. If present this method will be called before doing
-       constant folding of a node, with that node as a parameter. If
-       it return True, we will not generate C code when doing constant
-       folding of this node.  This is useful when the compilation of
-       the C code will be longer then the computation in python
-       (e.g. Elemwise of scalars).
-
-       In addition, this allow to lower the number of compiled module
-       and disk access. Particularly useful when the file system load
-       is high or when aesara compilation directory is shared by many
-       process (like on a network file server on a cluster).
-
     .. method:: get_params(node)
 
        (optional) If defined, should return the runtime params the op

--- a/tests/tensor/test_basic_opt.py
+++ b/tests/tensor/test_basic_opt.py
@@ -1428,7 +1428,6 @@ def test_local_useless_inc_subtensor():
     o_shape = set_subtensor(s, specify_shape(y, s.shape))
     f_shape = function([x, y], o_shape)
     topo = f_shape.maker.fgraph.toposort()
-    # aesara.printing.debugprint(f_shape)
     assert any(isinstance(n.op, IncSubtensor) for n in topo)
     out = f_shape([[2, 3, 6, 7]], [[8, 9]])
     assert (out == np.asarray([[8, 3, 9, 7]])).all()
@@ -1443,7 +1442,6 @@ def test_local_useless_subtensor():
         (slice(0, None), slice(0, None)),
     ]:
         f = function([x], exp(x).__getitem__(dims), mode=mode_opt)
-        # aesara.printing.debugprint(f)
         prog = f.maker.fgraph.toposort()
         assert prog[0].op == exp
         assert len(prog) == 1
@@ -1462,7 +1460,6 @@ def test_local_useless_subtensor():
         ((slice(0, 1), 1), False),
     ]:
         f = function([x], exp(x_c).__getitem__(dims), mode=mode_opt)
-        # aesara.printing.debugprint(f)
         prog = f.maker.fgraph.toposort()
         if res:
             assert isinstance(prog[0].op, SpecifyShape), dims
@@ -1517,7 +1514,6 @@ def test_local_useless_subtensor():
         ]
     ):
         f = function([x], exp(x).__getitem__(dims), mode=mode_opt)
-        # aesara.printing.debugprint(f)
         prog = f.maker.fgraph.toposort()
         if res:
             assert prog[0].op == exp, dims
@@ -1534,7 +1530,6 @@ def test_local_useless_subtensor():
         ]
     ):
         f = function([x], exp(x_c).__getitem__(dims), mode=mode_opt)
-        # aesara.printing.debugprint(f)
         prog = f.maker.fgraph.toposort()
         if res:
             assert prog[0].op == exp, dims
@@ -1551,7 +1546,6 @@ def test_local_useless_subtensor():
         ]
     ):
         f = function([x, s], exp(x).__getitem__(dims), mode=mode_opt)
-        # aesara.printing.debugprint(f)
         prog = f.maker.fgraph.toposort()
         if res:
             assert prog[0].op == exp, dims
@@ -1575,7 +1569,6 @@ def test_local_useless_subtensor():
         (aet.arange(1, 2), False),
     ):
         f = function([x], exp(x_c).__getitem__(dims), mode=mode_opt)
-        # aesara.printing.debugprint(f)
         prog = f.maker.fgraph.toposort()
         if res:
             assert isinstance(prog[0].op, SpecifyShape), dims
@@ -2131,15 +2124,12 @@ class TestLocalSubtensorMerge:
         g = function(
             [x, y], x[y::][-1], mode=mode_opt.excluding("local_subtensor_merge")
         )
-        # aesara.printing.debugprint(f, print_type=True)
 
         # Check stacktrace was copied over correctly after opt was applied
         assert check_stack_trace(f, ops_to_check=Subtensor)
 
         topo = f.maker.fgraph.toposort()
-        # print [t for t in topo if isinstance(t.op, Subtensor)]
         assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-        # print topo[-1].op
         assert isinstance(topo[-1].op, DeepCopyOp)
 
         for x_s in self.x_shapes:
@@ -2168,11 +2158,8 @@ class TestLocalSubtensorMerge:
             # Check stacktrace was copied over correctly after opt was applied
             assert check_stack_trace(f, ops_to_check=Subtensor)
 
-            # aesara.printing.debugprint(f, print_type=True)
             topo = f.maker.fgraph.toposort()
-            # print [t for t in topo if isinstance(t.op, Subtensor)]
             assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-            # print topo[-1].op
             assert isinstance(topo[-1].op, DeepCopyOp)
 
             for x_s in self.x_shapes:
@@ -2196,15 +2183,12 @@ class TestLocalSubtensorMerge:
         g = function(
             [x, y], x[::-1][y], mode=mode_opt.excluding("local_subtensor_merge")
         )
-        # aesara.printing.debugprint(f, print_type=True)
 
         # Check stacktrace was copied over correctly after opt was applied
         assert check_stack_trace(f, ops_to_check=Subtensor)
 
         topo = f.maker.fgraph.toposort()
-        # print [t for t in topo if isinstance(t.op, Subtensor)]
         assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-        # print topo[-1].op
         assert isinstance(topo[-1].op, DeepCopyOp)
 
         for x_s in self.x_shapes:
@@ -2227,11 +2211,8 @@ class TestLocalSubtensorMerge:
             # Check stacktrace was copied over correctly after opt was applied
             assert check_stack_trace(f, ops_to_check=Subtensor)
 
-            # aesara.printing.debugprint(f, print_type=True)
             topo = f.maker.fgraph.toposort()
-            # print [t for t in topo if isinstance(t.op, Subtensor)]
             assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-            # print topo[-1].op
             assert isinstance(topo[-1].op, DeepCopyOp)
 
             for x_s in self.x_shapes:
@@ -2247,12 +2228,8 @@ class TestLocalSubtensorMerge:
         # Check stacktrace was copied over correctly after opt was applied
         assert check_stack_trace(f, ops_to_check=Subtensor)
 
-        # aesara.printing.debugprint(f, print_type=True)
-
         topo = f.maker.fgraph.toposort()
-        # print [t for t in topo if isinstance(t.op, Subtensor)]
         assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-        # print topo[-1].op
         assert isinstance(topo[-1].op, DeepCopyOp)
 
         for x_s in self.x_shapes:
@@ -2270,11 +2247,8 @@ class TestLocalSubtensorMerge:
                 # Check stacktrace was copied over correctly after opt was applied
                 assert check_stack_trace(f, ops_to_check=Subtensor)
 
-                # aesara.printing.debugprint(f, print_type=True)
                 topo = f.maker.fgraph.toposort()
-                # print [t for t in topo if isinstance(t.op, Subtensor)]
                 assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-                # print topo[-1].op
                 assert isinstance(topo[-1].op, DeepCopyOp)
 
                 for x_s in self.x_shapes:
@@ -2291,12 +2265,8 @@ class TestLocalSubtensorMerge:
         # Check stacktrace was copied over correctly after opt was applied
         assert check_stack_trace(f, ops_to_check=Subtensor)
 
-        # aesara.printing.debugprint(f, print_type=True)
-
         topo = f.maker.fgraph.toposort()
-        # print [t for t in topo if isinstance(t.op, Subtensor)]
         assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-        # print topo[-1].op
         assert isinstance(topo[-1].op, DeepCopyOp)
 
         for x_s in self.x_shapes:
@@ -2340,12 +2310,8 @@ class TestLocalSubtensorMerge:
         # Check stacktrace was copied over correctly after opt was applied
         assert check_stack_trace(f, ops_to_check=Subtensor)
 
-        # aesara.printing.debugprint(f, print_type=True)
-
         topo = f.maker.fgraph.toposort()
-        # print [t for t in topo if isinstance(t.op, Subtensor)]
         assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-        # print topo[-1].op
         assert isinstance(topo[-1].op, DeepCopyOp)
 
         b1r = self.rng.permutation(list(range(-8, 8)))[:2]
@@ -2434,12 +2400,8 @@ class TestLocalSubtensorMerge:
         # Check stacktrace was copied over correctly after opt was applied
         assert check_stack_trace(f, ops_to_check=Subtensor)
 
-        # aesara.printing.debugprint(f, print_type=True)
-
         topo = f.maker.fgraph.toposort()
-        # print [t for t in topo if isinstance(t.op, Subtensor)]
         assert len([t for t in topo if isinstance(t.op, Subtensor)]) == 1
-        # print topo[-1].op
         assert isinstance(topo[-1].op, DeepCopyOp)
 
         b_r = self.rng.permutation(list(range(-4, 4)))[:3]
@@ -2470,9 +2432,6 @@ class TestLocalSubtensorMerge:
                                 # any exception
                                 n_ok += 1
                                 f(x_val, b_v, e_v, s_v, i_v)
-
-            # print 'shape: %s' % (x_s,)
-            # print '%% OK: %f' % (float(n_ok) * 100 / (n_ok + n_index_err))
 
     @pytest.mark.slow
     def test_none_slice(self):
@@ -2530,7 +2489,6 @@ class TestLocalSubtensorMerge:
             assert check_stack_trace(f, ops_to_check=Subtensor, bug_print="ignore")
 
             topo = f.maker.fgraph.toposort()
-            # print [t for t in topo if isinstance(t.op, Subtensor)]
             assert len([t for t in topo if isinstance(t.op, Subtensor)]) <= 1
             assert isinstance(topo[-1].op, DeepCopyOp)
 
@@ -2589,7 +2547,6 @@ class TestLocalSubtensorMerge:
             assert check_stack_trace(f, ops_to_check=Subtensor)
 
             topo = f.maker.fgraph.toposort()
-            # print [t for t in topo if isinstance(t.op, Subtensor)]
             assert len([t for t in topo if isinstance(t.op, Subtensor)]) <= 1
             assert isinstance(topo[-1].op, DeepCopyOp)
 
@@ -3386,7 +3343,6 @@ class TestLocalCanonicalizeAlloc:
 
         f = function([x], [y], mode=mode)
         op_classes = [node.op.__class__ for node in f.maker.fgraph.toposort()]
-        print(op_classes)
 
         # We are supposed to test if tensr.Alloc is not in op_classes,
         # but since the proper proper optimization is not currently
@@ -3743,7 +3699,8 @@ class TestShapeOptimizer:
 
         mode = get_default_mode().excluding("ShapeOpt")
         f = function([X], expr, mode=mode)
-        print(f([[1, 2], [2, 3]]))
+        # FIXME: This is not a good test.
+        f([[1, 2], [2, 3]])
 
 
 class TestAssert(utt.InferShapeTester):
@@ -4057,7 +4014,6 @@ class TestCastCast:
 def test_constant_folding():
     # Test that constant folding get registered at fast_compile
     # An error removed that registration during the registration.
-
     x = dvector()
     mode = get_mode("FAST_COMPILE").excluding("fusion")
     f = function([x], [x * 2, x + x], mode=mode)
@@ -4078,16 +4034,18 @@ def test_constant_folding():
 
 @pytest.mark.xfail(
     reason="Aesara optimizes constant before stabilization. "
-    "This breaks stabilization optimization in some "
-    "cases. See #504."
+    "This breaks stabilization optimizations in some "
+    "cases. See #504.",
+    raises=AssertionError,
 )
 def test_constant_get_stabilized():
-    # Currently Aesara enable the constant_folding optimization before stabilization optimization.
-    # This cause some stabilization optimization not being implemented and thus cause inf value to appear
-    # when it should not.
-    #
-    # .. note: we can't simply move the constant_folding optimization to specialize as this break other optimization!
-    # We will need to partially duplicate some canonicalize optimzation to specialize to fix this issue.
+    # Currently Aesara enables the `constant_folding` optimization before stabilization optimization.
+    # This caused some stabilization optimizations to not be activated and that
+    # caused inf values to appear when they should not.
+
+    # We can't simply move the `constant_folding` optimization to
+    # specialize since this will break other optimizations.  We will need to
+    # partially duplicate some canonicalize optimizations to fix this issue.
 
     x2 = scalar()
     y2 = log(1 + exp(x2))
@@ -4102,9 +4060,6 @@ def test_constant_get_stabilized():
     x = aet.as_tensor_variable(800)
     y = log(1 + exp(x))
     f = function([], y, mode=mode)
-    assert len(f.maker.fgraph.toposort()) == 0
-    assert np.isinf(f())
-
     # When this error is fixed, the following line should be ok.
     assert f() == 800, f()
 
@@ -4524,13 +4479,9 @@ class TestMakeVector(utt.InferShapeTester):
             gb = aesara.gradient.grad(s, b, disconnected_inputs="ignore")
             gi = aesara.gradient.grad(s, i, disconnected_inputs="ignore")
             gd = aesara.gradient.grad(s, d, disconnected_inputs="ignore")
-            # print 'gb =', gb
-            # print 'gi =', gi
-            # print 'gd =', gd
 
             g = function([b, i, d], [gb, gi, gd])
             g_val = g(val[b], val[i], val[d])
-            # print 'g_val =', g_val
 
             if dtype in int_dtypes:
                 # The gradient should be 0
@@ -4733,7 +4684,6 @@ def test_local_join_make_vector():
     mv = MakeVector(config.floatX)
     s = aet.join(0, mv(a), v, mv(b, c), mv(d, e))
     f = function([a, b, c, d, e, v], s, mode=mode_opt)
-    aesara.printing.debugprint(f)
     val = f(1, 2, 3, 4, 6, [7, 8])
     assert np.all(val == [1, 7, 8, 2, 3, 4, 6])
     e = f.maker.fgraph.toposort()


### PR DESCRIPTION
This PR simplifies the constant folding API by removing the unnecessary `COp.python_constant_folding` method.