### PR TITLE
Convert as_tensor_variable to a singledispatch function

### DIFF
--- a/aesara/gpuarray/type.py
+++ b/aesara/gpuarray/type.py
@@ -643,11 +643,6 @@ EQ_MAP.update(list((v, k) for k, v in EQ_MAP.items()))
 
 
 class _operators(_tensor_py_operators):
-    def _as_TensorVariable(self):
-        from .basic_ops import host_from_gpu
-
-        return host_from_gpu(self)
-
     def _as_GpuArrayVariable(self, context_name):
         if self.type.context_name == context_name:
             return self
@@ -655,6 +650,13 @@ class _operators(_tensor_py_operators):
             from .basic_ops import GpuToGpu
 
             return GpuToGpu(context_name)(self)
+
+
+@aet._as_tensor_variable.register(_operators)
+def _as_tensor_operators(x, **kwargs):
+    from aesara.gpuarray.basic_ops import host_from_gpu
+
+    return host_from_gpu(x)
 
 
 class GpuArrayVariable(_operators, Variable):

--- a/aesara/gradient.py
+++ b/aesara/gradient.py
@@ -1642,7 +1642,7 @@ class numeric_grad:
         for i, (a, b) in enumerate(zip(g_pt, self.gf)):
             if a.shape != b.shape:
                 raise ValueError(
-                    f"argument element {i} has wrong shape {str(a.shape, b.shape)}"
+                    f"argument element {i} has wrong shapes {a.shape}, {b.shape}"
                 )
             errs.append(numeric_grad.abs_rel_err(a, b))
         return errs

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -4,6 +4,41 @@
 __docformat__ = "restructuredtext en"
 
 import warnings
+from functools import singledispatch
+
+
+def as_tensor_variable(x, name=None, ndim=None, **kwargs):
+    """Convert `x` into the appropriate `TensorType`.
+
+    This function is often used by `make_node` methods of `Op` subclasses to
+    turn ndarrays, numbers, `Scalar` instances, `Apply` instances and
+    `TensorType` instances into valid input list elements.
+
+    Parameters
+    ----------
+    x : Apply or Variable or numpy.ndarray or number
+        This thing will be transformed into a `Variable` in a sensible way. An
+        ndarray argument will not be copied, but a list of numbers will be
+        copied to make an ndarray.
+    name : str or None
+        If a new `Variable` instance is created, it will be named with this
+        string.
+    ndim : None or integer
+        Return a Variable with this many dimensions.
+
+    Raises
+    ------
+    TypeError
+        If `x` cannot be converted to a TensorType Variable.
+
+    """
+    return _as_tensor_variable(x, name, ndim, **kwargs)
+
+
+@singledispatch
+def _as_tensor_variable(x, name, ndim, **kwargs):
+    raise NotImplementedError("")
+
 
 import aesara.tensor.exceptions
 from aesara.gradient import consider_constant, grad, hessian, jacobian

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -241,9 +241,6 @@ class TensorType(CType):
         and dtype and have "compatible" broadcastable pattern.
 
         """
-        if hasattr(other, "_as_TensorVariable"):
-            other = other._as_TensorVariable()
-
         if not isinstance(other, Variable):
             # The value is not a Variable: we cast it into
             # a Constant of the appropriate Type.

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -522,6 +522,14 @@ class TestAsTensorVariable:
         res = aet.as_tensor(y)
         assert isinstance(res.owner.op, MakeVector)
 
+    def test_multi_out(self):
+        class TestOp(Op):
+            def make_node(self, a, b):
+                return Apply(self, [a, b], [a, b])
+
+        with pytest.raises(TypeError):
+            aet.as_tensor(TestOp(matrix(), matrix()))
+
 
 class TestAlloc:
     dtype = config.floatX
@@ -3049,7 +3057,7 @@ def test_dimshuffle_duplicate():
 
 
 class TestGetScalarConstantValue:
-    def test_get_scalar_constant_value(self):
+    def test_basic(self):
         a = aet.stack([1, 2, 3])
         assert get_scalar_constant_value(a[0]) == 1
         assert get_scalar_constant_value(a[1]) == 2

--- a/tests/test_ifelse.py
+++ b/tests/test_ifelse.py
@@ -35,6 +35,21 @@ class TestIfelse(utt.OptimizationTestMixin):
         else:
             return IfElse(n, as_view=True)
 
+    def test_wrong_n_outs(self):
+        x = vector("x", dtype=self.dtype)
+        c = iscalar("c")
+        with pytest.raises(ValueError):
+            IfElse(0)(c, x, x)
+
+    def test_const_Op_argument(self):
+        x = vector("x", dtype=self.dtype)
+        y = np.array([2.0, 3.0], dtype=self.dtype)
+        c = iscalar("c")
+        f = function([c, x], IfElse(1)(c, x, y), mode=self.mode)
+
+        val = f(0, np.r_[1.0, 2.0].astype(self.dtype))
+        assert np.array_equal(val, y)
+
     def test_lazy_if(self):
         # Tests that lazy if works .. even if the two results have different
         # shapes but the same type (i.e. both vectors, or matrices or


### PR DESCRIPTION
This PR converts `as_tensor_variable` to a `functools.singledispatch` function.  Aside from clarifying the logic and simplifying the implementation, this change should make it much easier to improve and (locally) customize conversion operations.

I might take a pass at #96 while I'm at it.