### PR TITLE
Fix aesara.gpuarray access that fails on Windows

### DIFF
--- a/aesara/gpuarray/dnn.py
+++ b/aesara/gpuarray/dnn.py
@@ -66,7 +66,12 @@ except ImportError:
 WIN32_CUDNN_NAMES = ["cudnn64_7.dll", "cudnn64_6.dll", "cudnn64_5.dll"]
 
 if sys.platform == "win32":
-    aesara.gpuarray.pathparse.PathParser(config.dnn__bin_path)
+    try:
+        from aesara.gpuarray.pathparse import PathParser
+
+        PathParser(config.dnn__bin_path)
+    except ImportError:
+        pass
 
 
 def _load_lib(name):

--- a/aesara/misc/check_blas.py
+++ b/aesara/misc/check_blas.py
@@ -78,9 +78,13 @@ def execute(execute=True, verbose=True, M=2000, N=2000, K=2000, iters=10, order=
 
     f()  # Ignore first function call to get representative time.
     if execute:
-        sync = hasattr(aesara, "gpuarray") and isinstance(
-            c, aesara.gpuarray.GpuArraySharedVariable
-        )
+        try:
+            from aesara.gpuarray import GpuArraySharedVariable
+
+            sync = isinstance(c, GpuArraySharedVariable)
+        except ImportError:
+            sync = False
+
         if sync:
             # Make sure we don't include the time from the first call
             c.get_value(borrow=True, return_internal_type=True).sync()

--- a/aesara/scan/opt.py
+++ b/aesara/scan/opt.py
@@ -1063,18 +1063,7 @@ class ScanInplaceOptimizer(GlobalOptimizer):
 
     def apply(self, fgraph):
 
-        # Depending on the value of gpua_flag, get the list of memory
-        # allocation ops that the optimization should be able to
-        # handle
         alloc_ops = (Alloc, AllocEmpty)
-        if self.gpua_flag:
-            # gpuarray might be imported but not its GpuAlloc and
-            # GpuAllopEmpty ops.
-            try:
-                alloc_ops += (aesara.gpuarray.GpuAlloc, aesara.gpuarray.GpuAllocEmpty)
-            except Exception:
-                pass
-
         nodes = fgraph.toposort()[::-1]
         scan_nodes = [
             x


### PR DESCRIPTION
This PR fixes an issue in Windows that's caused by an invalid attribute access on `aesara.gpuarray.pathparse` during loading of `aesara.gpuarray.dnn`.  It also changes and removes similar `aesara.gpuarray` invocations.