### PR TITLE
Remove deprecated aesara.tensor.nlinalg.AllocDiag

### DIFF
--- a/aesara/link/jax/jax_dispatch.py
+++ b/aesara/link/jax/jax_dispatch.py
@@ -16,8 +16,10 @@ from aesara.scan.op import Scan
 from aesara.scan.utils import scan_args as ScanArgs
 from aesara.tensor.basic import (
     Alloc,
+    AllocDiag,
     AllocEmpty,
     ARange,
+    ExtractDiag,
     Eye,
     Join,
     MakeVector,
@@ -41,11 +43,9 @@ from aesara.tensor.extra_ops import (
 from aesara.tensor.math import Dot, MaxAndArgmax
 from aesara.tensor.nlinalg import (
     SVD,
-    AllocDiag,
     Det,
     Eig,
     Eigh,
-    ExtractDiag,
     MatrixInverse,
     QRFull,
     QRIncomplete,
@@ -265,6 +265,16 @@ def jax_funcify_Second(op):
         return jnp.broadcast_to(y, x.shape)
 
     return second
+
+
+@jax_funcify.register(AllocDiag)
+def jax_funcify_AllocDiag(op):
+    offset = op.offset
+
+    def allocdiag(v, offset=offset):
+        return jnp.diag(v, k=offset)
+
+    return allocdiag
 
 
 @jax_funcify.register(AllocEmpty)
@@ -833,14 +843,6 @@ def jax_funcify_Cholesky(op):
         return jsp.linalg.cholesky(a, lower=lower).astype(a.dtype)
 
     return cholesky
-
-
-@jax_funcify.register(AllocDiag)
-def jax_funcify_AllocDiag(op):
-    def alloc_diag(x):
-        return jnp.diag(x)
-
-    return alloc_diag
 
 
 @jax_funcify.register(Solve)

--- a/aesara/sandbox/linalg/__init__.py
+++ b/aesara/sandbox/linalg/__init__.py
@@ -1,12 +1,3 @@
 from aesara.sandbox.linalg.ops import psd, spectral_radius_bound
-from aesara.tensor.nlinalg import (
-    alloc_diag,
-    det,
-    diag,
-    eig,
-    eigh,
-    extract_diag,
-    matrix_inverse,
-    trace,
-)
+from aesara.tensor.nlinalg import det, eig, eigh, matrix_inverse, trace
 from aesara.tensor.slinalg import cholesky, eigvalsh, solve

--- a/aesara/sandbox/linalg/ops.py
+++ b/aesara/sandbox/linalg/ops.py
@@ -16,13 +16,7 @@ from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.math import Dot, Prod, dot, log
 from aesara.tensor.math import pow as aet_pow
 from aesara.tensor.math import prod
-from aesara.tensor.nlinalg import (
-    MatrixInverse,
-    det,
-    extract_diag,
-    matrix_inverse,
-    trace,
-)
+from aesara.tensor.nlinalg import MatrixInverse, det, matrix_inverse, trace
 from aesara.tensor.slinalg import Cholesky, Solve, cholesky, imported_scipy, solve
 
 
@@ -320,7 +314,7 @@ def local_det_chol(fgraph, node):
         for (cl, xpos) in fgraph.clients[x]:
             if isinstance(cl.op, Cholesky):
                 L = cl.outputs[0]
-                return [prod(extract_diag(L) ** 2)]
+                return [prod(aet.extract_diag(L) ** 2)]
 
 
 @register_canonicalize

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -3811,6 +3811,10 @@ class ExtractDiag(Op):
             self.axis2 = 1
 
 
+extract_diag = ExtractDiag()
+# TODO: optimization to insert ExtractDiag with view=True
+
+
 def diagonal(a, offset=0, axis1=0, axis2=1):
     """
     A helper function for `ExtractDiag`. It accepts tensor with
@@ -4298,4 +4302,5 @@ __all__ = [
     "constant",
     "as_tensor_variable",
     "as_tensor",
+    "extract_diag",
 ]

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -18,7 +18,6 @@ from aesara.misc.safe_asarray import _asarray
 from aesara.scalar import int32 as int_t
 from aesara.scalar import upcast
 from aesara.tensor import basic as aet
-from aesara.tensor import nlinalg
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.math import abs_
 from aesara.tensor.math import all as aet_all
@@ -961,7 +960,7 @@ class FillDiagonal(Op):
             )
         wr_a = fill_diagonal(grad, 0)  # valid for any number of dimensions
         # diag is only valid for matrices
-        wr_val = nlinalg.diag(grad).sum()
+        wr_val = aet.diag(grad).sum()
         return [wr_a, wr_val]
 
 

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -265,7 +265,7 @@ def test_jax_basic():
         ],
     )
 
-    out = aet_nlinalg.alloc_diag(b)
+    out = aet.diag(b)
     out_fg = FunctionGraph([b], [out])
     compare_jax_and_py(out_fg, [np.arange(10).astype(config.floatX)])
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3225,19 +3225,21 @@ class TestSize:
 
 
 class TestDiag:
-    # Test that aet.diag has the same behavior as np.diag.
-    # np.diag has two behaviors:
-    #
-    # (1) when given a vector, it returns a matrix with that vector as the
-    # diagonal.
-    # (2) when given a matrix, returns a vector which is the diagonal of the
-    # matrix.
-    #
-    # (1) and (2) are tested by test_alloc_diag and test_extract_diag
-    # respectively.
-    #
-    # test_diag test makes sure that linalg.diag instantiates
-    # the right op based on the dimension of the input.
+    """
+    Test that linalg.diag has the same behavior as numpy.diag.
+    numpy.diag has two behaviors:
+    (1) when given a vector, it returns a matrix with that vector as the
+    diagonal.
+    (2) when given a matrix, returns a vector which is the diagonal of the
+    matrix.
+
+    (1) and (2) are tested by test_alloc_diag and test_extract_diag
+    respectively.
+
+    test_diag test makes sure that linalg.diag instantiates
+    the right op based on the dimension of the input.
+    """
+
     def setup_method(self):
         self.mode = None
         self.shared = shared


### PR DESCRIPTION
This PR removes the deprecated (and duplicated) `aesara.tensor.nlinalg.AllocDiag`.

Closes #313.