### PR TITLE
Add logsoftmax and fix for jax_funcify_join

### DIFF
--- a/aesara/link/jax/jax_dispatch.py
+++ b/aesara/link/jax/jax_dispatch.py
@@ -52,7 +52,7 @@ from aesara.tensor.nlinalg import (
     QRFull,
     QRIncomplete,
 )
-from aesara.tensor.nnet.basic import Softmax, LogSoftmax
+from aesara.tensor.nnet.basic import LogSoftmax, Softmax
 from aesara.tensor.nnet.sigm import ScalarSoftplus
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape

--- a/aesara/link/jax/jax_dispatch.py
+++ b/aesara/link/jax/jax_dispatch.py
@@ -794,6 +794,8 @@ def jax_funcify_DimShuffle(op):
 @jax_funcify.register(Join)
 def jax_funcify_Join(op):
     def join(axis, *tensors):
+        # tensors could also be tuples, and in this case they don't have a ndim
+        tensors = [jnp.asarray(tensor) for tensor in tensors]
         view = op.view
         if (view != -1) and all(
             [

--- a/aesara/link/jax/jax_dispatch.py
+++ b/aesara/link/jax/jax_dispatch.py
@@ -52,7 +52,7 @@ from aesara.tensor.nlinalg import (
     QRFull,
     QRIncomplete,
 )
-from aesara.tensor.nnet.basic import Softmax
+from aesara.tensor.nnet.basic import Softmax, LogSoftmax
 from aesara.tensor.nnet.sigm import ScalarSoftplus
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
@@ -273,6 +273,14 @@ def jax_funcify_Softmax(op):
         return jax.nn.softmax(x)
 
     return softmax
+
+
+@jax_funcify.register(LogSoftmax)
+def jax_funcify_LogSoftmax(op):
+    def log_softmax(x):
+        return jax.nn.log_softmax(x)
+
+    return log_softmax
 
 
 @jax_funcify.register(ScalarSoftplus)

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -703,6 +703,45 @@ def test_jax_Dimshuffle():
     compare_jax_and_py(x_fg, [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)])
 
 
+def test_jax_Join():
+    a = matrix("a")
+    b = matrix("b")
+
+    x = aet.join(0, a, b)
+    x_fg = FunctionGraph([a, b], [x])
+    compare_jax_and_py(
+        x_fg,
+        [
+            np.c_[[1.0, 2.0, 3.0]].astype(config.floatX),
+            np.c_[[4.0, 5.0, 6.0]].astype(config.floatX),
+        ],
+    )
+    compare_jax_and_py(
+        x_fg,
+        [
+            np.c_[[1.0, 2.0, 3.0]].astype(config.floatX),
+            np.c_[[4.0, 5.0]].astype(config.floatX),
+        ],
+    )
+
+    x = aet.join(1, a, b)
+    x_fg = FunctionGraph([a, b], [x])
+    compare_jax_and_py(
+        x_fg,
+        [
+            np.c_[[1.0, 2.0, 3.0]].astype(config.floatX),
+            np.c_[[4.0, 5.0, 6.0]].astype(config.floatX),
+        ],
+    )
+    compare_jax_and_py(
+        x_fg,
+        [
+            np.c_[[1.0, 2.0], [3.0, 4.0]].astype(config.floatX),
+            np.c_[[5.0, 6.0]].astype(config.floatX),
+        ],
+    )
+
+
 def test_jax_variadic_Scalar():
     mu = vector("mu", dtype=config.floatX)
     mu.tag.test_value = np.r_[0.1, 1.1].astype(config.floatX)

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -777,6 +777,10 @@ def test_nnet():
     fgraph = FunctionGraph([x], [out])
     compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
 
+    out = aet_nnet.logsoftmax(x)
+    fgraph = FunctionGraph([x], [out])
+    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+
 
 def test_tensor_basics():
     y = vector("y")


### PR DESCRIPTION
Add a LogSoftmax implementation for `jax_funcify`.

Also, this adds a jax tensor conversion for `jax_funcify_Join`. I'm not sure this is the best solution, it might also not be needed if optimizations are used. Without this change this fails:

```python
import pymc3 as pm
import aesara.tensor as aet
import aesara
import pymc3.sampling_jax
import numpy as np

with pm.Model() as model:
    a = pm.Normal('a', shape=(13, 3, 5))
    b = pm.Normal('b', shape=(17, 5, 7))
    pm.Normal('c', mu=aet.tensordot(a, b, axes=(2, 1)), shape=(13, 3, 17, 7))

with model:
    # fails with attribute access tuple.ndim
    trace = pymc3.sampling_jax.sample_numpyro_nuts()

# this doesn't fail, the join gets optimized away I think
func = model.logp_dlogp_function(mode=aesara.compile.mode.JAX)
func.set_extra_values({})
x = np.random.randn(func.size)

%%timeit
val, grad = func(x)
jax.device_get(grad)
```
cc @brandonwillard @OriolAbril 

closes: #340 and closes #339