### PR TITLE
Fix scan optimization bugs

### DIFF
--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -687,7 +687,6 @@ def walk(
     Yields
     ------
     nodes
-        When `build_inv` is ``True``, a inverse map is returned.
 
     Notes
     -----


### PR DESCRIPTION
This PR fixes a bug in the `Scan` optimizations that involve (re)creating nodes with an `Op` and another node's inputs.  Simply put, **do not create nodes using `Op.__call__` and a list of inputs obtained via `node.inputs`**.  Inputs obtained from a node via `node.inputs` can be used with `Op.make_node`, but not `Op.__call__`, because the latter is allowed to be a more flexible interface to `Op.make_node`.