### PR TITLE
Change reference count assertion to warning

### DIFF
--- a/aesara/link/vm.py
+++ b/aesara/link/vm.py
@@ -1043,8 +1043,12 @@ class VMLinker(LocalLinker):
                 dependencies=dependency_map_list,
             )
 
-            if platform.python_implementation() == "CPython":
-                assert c0 == sys.getrefcount(node_n_inputs)
+            if platform.python_implementation() == "CPython" and c0 != sys.getrefcount(
+                node_n_inputs
+            ):
+                logger.warning(
+                    "Detected reference count inconsistency after CVM construction"
+                )
         else:
             lazy = self.lazy
             if lazy is None:


### PR DESCRIPTION
This PR partially addresses the reference count assertion failure mentioned by @aseyboldt in #345.

In certain circumstances the reference count for `node_n_inputs` differs before and after the construction of a `CVM` object in `VMLinker`, causing an assertion to fail. So far this issue has only been seen in the context of compiling graphs in parallel with Dask.

The issue is difficult to reproduce, and it's unclear whether there is actually a leak. (@aseyboldt has a hypothesis that the issue is due to [Dask profiling](https://github.com/dask/distributed/blob/main/distributed/profile.py).) So I've changed the assertion to a warning.