### PR TITLE
Fix test exclusion in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         url=URL,
         license=LICENSE,
         platforms=PLATFORMS,
-        packages=find_packages(exclude=["tests.*"]),
+        packages=find_packages(exclude=["tests", "tests.*"]),
         install_requires=["numpy>=1.9.1", "scipy>=0.14", "filelock"],
         package_data={
             "": [


### PR DESCRIPTION
The "tests.*" exclusion only excludes test subpackages from being
installed, while "tests" itself is still installed.  List it explicitly
to exclude it as well.

(presuming most of the points below don't apply as I only modify `setup.py`)

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [ ] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.  If your commit description starts with "Fix...", then you're probably making this mistake.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
