### PR TITLE
Add missing NumPy functions to `aesara.tensor` at package-level and further `FunctionGraph` improvements

### DIFF
--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -63,13 +63,18 @@ from aesara.tensor.blas import batched_dot, batched_tensordot
 from aesara.tensor.extra_ops import (
     bartlett,
     bincount,
+    broadcast_shape,
+    broadcast_shape_iter,
+    broadcast_to,
     cumprod,
     cumsum,
+    diff,
     fill_diagonal,
     fill_diagonal_offset,
     ravel_multi_index,
     repeat,
     squeeze,
+    unique,
     unravel_index,
 )
 from aesara.tensor.io import *

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -1295,6 +1295,21 @@ class Unique(Op):
             self.axis = None
 
 
+def unique(
+    ar, return_index=False, return_inverse=False, return_counts=False, axis=None
+):
+    """Find the unique elements of an array.
+
+    Returns the sorted unique elements of an array. There are three optional
+    outputs in addition to the unique elements:
+
+    * the indices of the input array that give the unique values
+    * the indices of the unique array that reconstruct the input array
+    * the number of times each unique value comes up in the input array
+    """
+    return Unique(return_index, return_inverse, return_counts, axis)(ar)
+
+
 class UnravelIndex(Op):
     __props__ = ("order",)
 

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -41,6 +41,10 @@ class TestFunctionGraph:
             var3 = op1(var1)
             FunctionGraph([var3], [var2], clone=False)
 
+        with pytest.raises(ValueError):
+            var3 = op1(var1)
+            FunctionGraph([var3], clone=False)
+
     def test_init(self):
         var1 = MyVariable("var1")
         var2 = MyVariable("var2")
@@ -57,6 +61,19 @@ class TestFunctionGraph:
         assert fg.get_clients(var2) == [(var4.owner, 1)]
         assert fg.get_clients(var3) == [(var4.owner, 0), ("output", 0)]
         assert fg.get_clients(var4) == [("output", 1)]
+
+        fg = FunctionGraph(outputs=[var3, var4], clone=False)
+        assert fg.inputs == [var1, var2]
+
+        memo = {}
+        fg = FunctionGraph(outputs=[var3, var4], clone=True, memo=memo)
+
+        assert memo[var1].type == var1.type
+        assert memo[var1].name == var1.name
+        assert memo[var2].type == var2.type
+        assert memo[var2].name == var2.name
+        assert var3 in memo
+        assert var4 in memo
 
     def test_remove_client(self):
         var1 = MyVariable("var1")

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -58,7 +58,7 @@ class MyOp(Op):
         return Apply(self, inputs, outputs)
 
     def perform(self, node, inputs, outputs):
-        outputs[0] = np.array(inputs)
+        outputs[0] = np.array(inputs, dtype=np.object)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
This PR provides adds missing NumPy functions to `aesara.tensor` at package-level and provides better `FunctionGraph` options (e.g. optional `inputs`, allows one to provide and update a list of replacements, etc.)