### PR TITLE
Fix `nan` comparison in `Scalar.filter` and simplify `TensorType.values_eq`

### DIFF
--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -360,7 +360,7 @@ class Scalar(CType):
                     and isinstance(data, (float, np.floating))
                     and self.dtype == config.floatX
                 )
-                or data == converted_data
+                or np.array_equal(data, converted_data, equal_nan=True)
             ):
                 return py_type(data)
             else:

--- a/tests/scalar/test_type.py
+++ b/tests/scalar/test_type.py
@@ -51,3 +51,7 @@ def test_filter_float_subclass():
 
         filtered_nan = test_type.filter(nan)
         assert isinstance(filtered_nan, np.floating)
+
+    with config.change_flags(floatX="float64"):
+        filtered_nan = test_type.filter(nan)
+        assert isinstance(filtered_nan, np.floating)


### PR DESCRIPTION
This PR fixes an issue with `Scalar("float32").filter(np.single("nan"))` failing when `aesara.config = "float64"`.