### PR TITLE
Pass storage map during conversions

### DIFF
--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -117,7 +117,7 @@ def jax_typify_RandomState(state, **kwargs):
 
 
 @singledispatch
-def jax_funcify(op, **kwargs):
+def jax_funcify(op, node=None, storage_map=None, **kwargs):
     """Create a JAX compatible function from an Aesara `Op`."""
     raise NotImplementedError(f"No JAX conversion for the given `Op`: {op}")
 
@@ -594,21 +594,15 @@ def jax_funcify_AdvancedIncSubtensor(op, **kwargs):
 @jax_funcify.register(FunctionGraph)
 def jax_funcify_FunctionGraph(
     fgraph,
-    order=None,
-    input_storage=None,
-    output_storage=None,
-    storage_map=None,
+    node=None,
+    fgraph_name="jax_funcified_fgraph",
     **kwargs,
 ):
     return fgraph_to_python(
         fgraph,
         jax_funcify,
-        jax_typify,
-        order,
-        input_storage,
-        output_storage,
-        storage_map,
-        fgraph_name="jax_funcified_fgraph",
+        type_conversion_fn=jax_typify,
+        fgraph_name=fgraph_name,
         **kwargs,
     )
 

--- a/aesara/link/jax/linker.py
+++ b/aesara/link/jax/linker.py
@@ -7,14 +7,10 @@ from aesara.link.basic import JITLinker
 class JAXLinker(JITLinker):
     """A `Linker` that JIT-compiles NumPy-based operations using JAX."""
 
-    def fgraph_convert(
-        self, fgraph, order, input_storage, output_storage, storage_map, **kwargs
-    ):
+    def fgraph_convert(self, fgraph, **kwargs):
         from aesara.link.jax.dispatch import jax_funcify
 
-        return jax_funcify(
-            fgraph, order, input_storage, output_storage, storage_map, **kwargs
-        )
+        return jax_funcify(fgraph, **kwargs)
 
     def jit_compile(self, fn):
         import jax

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -100,11 +100,12 @@ def numba_funcify_ScalarOp(op, node, **kwargs):
 
     global_env = {"scalar_func": scalar_func}
 
+    scalar_op_fn_name = scalar_func.__name__
     scalar_op_src = f"""
-def scalar_op({input_names}):
+def {scalar_op_fn_name}({input_names}):
     return scalar_func({input_names})
     """
-    scalar_op_fn = compile_function_src(scalar_op_src, "scalar_op", global_env)
+    scalar_op_fn = compile_function_src(scalar_op_src, scalar_op_fn_name, global_env)
 
     return numba.njit(scalar_op_fn)
 
@@ -117,12 +118,13 @@ def numba_funcify_Elemwise(op, node, **kwargs):
 
     global_env = {"scalar_op": scalar_op_fn, "vectorize": numba.vectorize}
 
+    elemwise_fn_name = f"elemwise_{scalar_op_fn.__name__}"
     elemwise_src = f"""
 @vectorize
-def elemwise({input_names}):
+def {elemwise_fn_name}({input_names}):
     return scalar_op({input_names})
     """
-    elemwise_fn = compile_function_src(elemwise_src, "elemwise", global_env)
+    elemwise_fn = compile_function_src(elemwise_src, elemwise_fn_name, global_env)
 
     return elemwise_fn
 

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -60,7 +60,7 @@ def numba_typify(data, dtype=None, **kwargs):
 
 
 @singledispatch
-def numba_funcify(op, **kwargs):
+def numba_funcify(op, node=None, storage_map=None, **kwargs):
     """Create a Numba compatible function from an Aesara `Op`."""
     raise NotImplementedError(f"No Numba conversion for the given `Op`: {op}")
 
@@ -68,27 +68,23 @@ def numba_funcify(op, **kwargs):
 @numba_funcify.register(FunctionGraph)
 def numba_funcify_FunctionGraph(
     fgraph,
-    order=None,
-    input_storage=None,
-    output_storage=None,
-    storage_map=None,
+    node=None,
+    fgraph_name="jax_funcified_fgraph",
     **kwargs,
 ):
     return fgraph_to_python(
         fgraph,
         numba_funcify,
-        numba_typify,
-        order,
-        input_storage,
-        output_storage,
-        storage_map,
-        fgraph_name="numba_funcified_fgraph",
+        type_conversion_fn=numba_typify,
+        fgraph_name=fgraph_name,
         **kwargs,
     )
 
 
 @numba_funcify.register(ScalarOp)
 def numba_funcify_ScalarOp(op, node, **kwargs):
+    # TODO: Do we need to cache these functions so that we don't end up
+    # compiling the same Numba function over and over again?
 
     scalar_func_name = op.nfunc_spec[0]
 

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -25,9 +25,6 @@ from aesara.tensor.subtensor import (
 from aesara.tensor.type_other import MakeSlice
 
 
-incsubtensor_ops = (IncSubtensor, AdvancedIncSubtensor1)
-
-
 def slice_new(self, start, stop, step):
     fnty = llvm_Type.function(self.pyobj, [self.pyobj, self.pyobj, self.pyobj])
     fn = self._get_function(fnty, name="PySlice_New")

--- a/aesara/link/numba/linker.py
+++ b/aesara/link/numba/linker.py
@@ -6,14 +6,10 @@ from aesara.link.basic import JITLinker
 class NumbaLinker(JITLinker):
     """A `Linker` that JIT-compiles NumPy-based operations using Numba."""
 
-    def fgraph_convert(
-        self, fgraph, order, input_storage, output_storage, storage_map, **kwargs
-    ):
+    def fgraph_convert(self, fgraph, **kwargs):
         from aesara.link.numba.dispatch import numba_funcify
 
-        return numba_funcify(
-            fgraph, order, input_storage, output_storage, storage_map, **kwargs
-        )
+        return numba_funcify(fgraph, **kwargs)
 
     def jit_compile(self, fn):
         jitted_fn = numba.njit(fn)

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -1,4 +1,3 @@
-import ast
 import io
 import re
 import sys
@@ -574,7 +573,6 @@ register_thunk_trace_excepthook()
 
 
 def compile_function_src(src, function_name, global_env=None, local_env=None):
-    src_ast = ast.parse(src)
 
     with NamedTemporaryFile(delete=False) as f:
         filename = f.name
@@ -586,7 +584,7 @@ def compile_function_src(src, function_name, global_env=None, local_env=None):
     if local_env is None:
         local_env = {}
 
-    mod_code = compile(src_ast, filename, mode="exec")
+    mod_code = compile(src, filename, mode="exec")
     exec(mod_code, global_env, local_env)
 
     return local_env[function_name]

--- a/tests/link/test_utils.py
+++ b/tests/link/test_utils.py
@@ -6,7 +6,7 @@ from aesara import config
 from aesara.graph.basic import Apply
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op
-from aesara.link.utils import fgraph_to_python
+from aesara.link.utils import fgraph_to_python, get_name_for_object
 from aesara.scalar.basic import Add
 from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.type import scalar, vector
@@ -49,6 +49,9 @@ def test_fgraph_to_python_names():
         sig.parameters.keys()
     )
     assert (1, 2, 3, 4, 5) == out_jx(1, 2, 3, 4, 5)
+
+    obj = object()
+    assert get_name_for_object(obj) == type(obj).__name__
 
 
 def test_fgraph_to_python_once():


### PR DESCRIPTION
This PR cleans up some of the object naming used during Python function generation in the JAX and Numba backends.  It also exposes an enclosing `FunctionGraph`'s storage map for use by the subsequently called conversion functions (e.g. in `aesara.link.utils.fgraph_to_python`).  This can be used&mdash;for example&mdash;when a `FunctionGraph` contains another `FunctionGraph` that needs access to pre-"allocated" storage for&mdash;say&mdash;shared variables.