### PR TITLE
Update MultinomialRV docstring to match new broadcasting behavior

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -492,9 +492,10 @@ betabinom = BetaBinomialRV()
 class MultinomialRV(RandomVariable):
     """A Multinomial random variable type.
 
-    FYI: Length of the support dimension is determined by the last
+    Notes
+    -----
+    The length of the support dimension is determined by the last
     dimension in the *second* parameter (i.e.  the probabilities vector).
-
     """
 
     name = "multinomial"

--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -492,8 +492,8 @@ betabinom = BetaBinomialRV()
 class MultinomialRV(RandomVariable):
     """A Multinomial random variable type.
 
-    FYI: Support shape is determined by the first dimension in the *second*
-    parameter (i.e.  the probabilities vector).
+    FYI: Length of the support dimension is determined by the last
+    dimension in the *second* parameter (i.e.  the probabilities vector).
 
     """
 


### PR DESCRIPTION
In ce9c17f3c39b2ae09cb4b4bb8ad0d06ae66d8fd6 the RV was changed such that `p` can be multi-dimensional instead of just 1-dimensional.
Since then the support length is determined by the **last** dimension of `p`.