### PR TITLE
Implement Numba conversion for `CAReduce` `Op`s

### DIFF
--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -16,7 +16,11 @@ from aesara.compile.ops import DeepCopyOp, ViewOp
 from aesara.graph.basic import Apply
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.type import Type
-from aesara.link.utils import compile_function_src, fgraph_to_python
+from aesara.link.utils import (
+    compile_function_src,
+    fgraph_to_python,
+    get_name_for_object,
+)
 from aesara.scalar.basic import (
     Cast,
     Clip,
@@ -205,7 +209,7 @@ def numba_funcify_ScalarOp(op, node, **kwargs):
 
     global_env = {"scalar_func": scalar_func}
 
-    scalar_op_fn_name = scalar_func.__name__
+    scalar_op_fn_name = get_name_for_object(scalar_func)
     scalar_op_src = f"""
 def {scalar_op_fn_name}({input_names}):
     return scalar_func({input_names})
@@ -223,7 +227,7 @@ def numba_funcify_Elemwise(op, node, **kwargs):
 
     global_env = {"scalar_op": scalar_op_fn, "numba_vectorize": numba.vectorize}
 
-    elemwise_fn_name = f"elemwise_{scalar_op_fn.__name__}"
+    elemwise_fn_name = f"elemwise_{get_name_for_object(scalar_op_fn)}"
     elemwise_src = f"""
 @numba_vectorize
 def {elemwise_fn_name}({input_names}):

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -35,6 +35,7 @@ from aesara.tensor.basic import (
     AllocDiag,
     AllocEmpty,
     ARange,
+    ExtractDiag,
     Join,
     MakeVector,
     Rebroadcast,
@@ -819,3 +820,16 @@ def numba_funcify_Join(op, **kwargs):
         return np.concatenate(tensors, to_scalar(axis))
 
     return join
+
+
+@numba_funcify.register(ExtractDiag)
+def numba_funcify_ExtractDiag(op, **kwargs):
+    offset = op.offset
+    # axis1 = op.axis1
+    # axis2 = op.axis2
+
+    @numba.njit
+    def extract_diag(x):
+        return np.diag(x, k=offset)
+
+    return extract_diag

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -55,13 +55,15 @@ def get_numba_type(
 ) -> numba.types.Type:
     """Create a Numba type object for a ``Type``."""
 
-    if isinstance(aesara_type, TensorType) and not force_scalar:
+    if isinstance(aesara_type, TensorType):
         dtype = aesara_type.numpy_dtype
-        numba_dtype = numba.np.numpy_support.from_dtype(dtype)
+        numba_dtype = numba.from_dtype(dtype)
+        if force_scalar:
+            return numba_dtype
         return numba.types.Array(numba_dtype, aesara_type.ndim, layout)
-    elif isinstance(aesara_type, Scalar) or force_scalar:
+    elif isinstance(aesara_type, Scalar):
         dtype = np.dtype(aesara_type.dtype)
-        numba_dtype = numba.np.numpy_support.from_dtype(dtype)
+        numba_dtype = numba.from_dtype(dtype)
         return numba_dtype
     else:
         raise NotImplementedError(f"Numba type not implemented for {aesara_type}")

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -35,6 +35,7 @@ from aesara.tensor.basic import (
     AllocDiag,
     AllocEmpty,
     ARange,
+    Join,
     MakeVector,
     Rebroadcast,
     ScalarFromTensor,
@@ -801,3 +802,20 @@ def numba_funcify_ARange(op, **kwargs):
         )
 
     return arange
+
+
+@numba_funcify.register(Join)
+def numba_funcify_Join(op, **kwargs):
+    view = op.view
+
+    if view != -1:
+        # TODO: Where (and why) is this `Join.view` even being used?  From a
+        # quick search, the answer appears to be "nowhere", so we should
+        # probably just remove it.
+        raise NotImplementedError("The `view` parameter to `Join` is not supported")
+
+    @numba.njit
+    def join(axis, *tensors):
+        return np.concatenate(tensors, to_scalar(axis))
+
+    return join

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -36,6 +36,7 @@ from aesara.tensor.basic import (
     AllocEmpty,
     ARange,
     ExtractDiag,
+    Eye,
     Join,
     MakeVector,
     Rebroadcast,
@@ -833,3 +834,15 @@ def numba_funcify_ExtractDiag(op, **kwargs):
         return np.diag(x, k=offset)
 
     return extract_diag
+
+
+@numba_funcify.register(Eye)
+def numba_funcify_Eye(op, **kwargs):
+    dtype = np.dtype(op.dtype)
+    dtype = numba.np.numpy_support.from_dtype(dtype)
+
+    @numba.njit
+    def eye(N, M, k):
+        return np.eye(to_scalar(N), to_scalar(M), to_scalar(k), dtype=dtype)
+
+    return eye

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -864,3 +864,74 @@ def test_ARange(start, stop, step, dtype):
             if not isinstance(i, (SharedVariable, Constant))
         ],
     )
+
+
+@pytest.mark.parametrize(
+    "careduce_fn, axis, v",
+    [
+        (aet.sum, 0, set_test_value(aet.vector(), np.arange(3, dtype=config.floatX))),
+        (aet.all, 0, set_test_value(aet.vector(), np.arange(3, dtype=config.floatX))),
+        (
+            aet.sum,
+            0,
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (
+            aet.sum,
+            (0, 1),
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (
+            aet.sum,
+            (1, 0),
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (
+            aet.sum,
+            None,
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (
+            aet.sum,
+            1,
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (aet.prod, 0, set_test_value(aet.vector(), np.arange(3, dtype=config.floatX))),
+        (
+            aet.prod,
+            0,
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (
+            aet.prod,
+            1,
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+    ],
+)
+def test_CAReduce(careduce_fn, axis, v):
+    g = careduce_fn(v, axis=axis)
+    g_fg = FunctionGraph(outputs=[g])
+
+    compare_numba_and_py(
+        g_fg,
+        [
+            i.tag.test_value
+            for i in g_fg.inputs
+            if not isinstance(i, (SharedVariable, Constant))
+        ],
+    )

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1050,3 +1050,35 @@ def test_ExtractDiag(val, offset):
             if not isinstance(i, (SharedVariable, Constant))
         ],
     )
+
+
+@pytest.mark.parametrize(
+    "n, m, k, dtype",
+    [
+        (set_test_value(aet.lscalar(), np.array(1, dtype=np.int64)), None, 0, None),
+        (
+            set_test_value(aet.lscalar(), np.array(1, dtype=np.int64)),
+            set_test_value(aet.lscalar(), np.array(2, dtype=np.int64)),
+            0,
+            "float32",
+        ),
+        (
+            set_test_value(aet.lscalar(), np.array(1, dtype=np.int64)),
+            set_test_value(aet.lscalar(), np.array(2, dtype=np.int64)),
+            1,
+            "int64",
+        ),
+    ],
+)
+def test_Eye(n, m, k, dtype):
+    g = aet.eye(n, m, k, dtype=dtype)
+    g_fg = FunctionGraph(outputs=[g])
+
+    compare_numba_and_py(
+        g_fg,
+        [
+            i.tag.test_value
+            for i in g_fg.inputs
+            if not isinstance(i, (SharedVariable, Constant))
+        ],
+    )

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1021,3 +1021,32 @@ def test_Join_view():
                 if not isinstance(i, (SharedVariable, Constant))
             ],
         )
+
+
+@pytest.mark.parametrize(
+    "val, offset",
+    [
+        (
+            set_test_value(
+                aet.matrix(), np.arange(10 * 10, dtype=config.floatX).reshape((10, 10))
+            ),
+            0,
+        ),
+        (
+            set_test_value(aet.vector(), np.arange(10, dtype=config.floatX)),
+            0,
+        ),
+    ],
+)
+def test_ExtractDiag(val, offset):
+    g = aet.diag(val, offset)
+    g_fg = FunctionGraph(outputs=[g])
+
+    compare_numba_and_py(
+        g_fg,
+        [
+            i.tag.test_value
+            for i in g_fg.inputs
+            if not isinstance(i, (SharedVariable, Constant))
+        ],
+    )

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -258,23 +258,27 @@ def test_create_numba_signature(v, expected, force_scalar):
     ],
 )
 def test_Elemwise(inputs, input_vals, output_fn):
-    out_fg = FunctionGraph(inputs, [output_fn(*inputs)])
+    out_fg = FunctionGraph(outputs=[output_fn(*inputs)])
     compare_numba_and_py(out_fg, input_vals)
 
 
 @pytest.mark.parametrize(
-    "inputs, input_values",
+    "inputs, input_values, scalar_fn",
     [
         (
             [aet.scalar("x"), aet.scalar("y")],
-            [np.array(10).astype(config.floatX), np.array(20).astype(config.floatX)],
+            [
+                np.array(10, dtype=config.floatX),
+                np.array(20, dtype=config.floatX),
+            ],
+            lambda x, y: x + y * 2 + aes.exp(x - y),
         ),
     ],
 )
-def test_numba_Composite(inputs, input_values):
+def test_numba_Composite(inputs, input_values, scalar_fn):
     x_s = aes.float64("x")
     y_s = aes.float64("y")
-    comp_op = Elemwise(Composite([x_s, y_s], [x_s + y_s * 2 + aes.exp(x_s - y_s)]))
+    comp_op = Elemwise(Composite([x_s, y_s], [scalar_fn(x_s, y_s)]))
     out_fg = FunctionGraph(inputs, [comp_op(*inputs)])
     compare_numba_and_py(out_fg, input_values)
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -935,3 +935,89 @@ def test_CAReduce(careduce_fn, axis, v):
             if not isinstance(i, (SharedVariable, Constant))
         ],
     )
+
+
+@pytest.mark.parametrize(
+    "vals, axis",
+    [
+        (
+            (
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(1, 2)).astype(config.floatX)
+                ),
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(1, 2)).astype(config.floatX)
+                ),
+            ),
+            0,
+        ),
+        (
+            (
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(2, 1)).astype(config.floatX)
+                ),
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(3, 1)).astype(config.floatX)
+                ),
+            ),
+            0,
+        ),
+        (
+            (
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(1, 2)).astype(config.floatX)
+                ),
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(1, 2)).astype(config.floatX)
+                ),
+            ),
+            1,
+        ),
+        (
+            (
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(2, 2)).astype(config.floatX)
+                ),
+                set_test_value(
+                    aet.matrix(), np.random.normal(size=(2, 1)).astype(config.floatX)
+                ),
+            ),
+            1,
+        ),
+    ],
+)
+def test_Join(vals, axis):
+    g = aet.join(axis, *vals)
+    g_fg = FunctionGraph(outputs=[g])
+
+    compare_numba_and_py(
+        g_fg,
+        [
+            i.tag.test_value
+            for i in g_fg.inputs
+            if not isinstance(i, (SharedVariable, Constant))
+        ],
+    )
+
+
+def test_Join_view():
+    vals = (
+        set_test_value(
+            aet.matrix(), np.random.normal(size=(2, 2)).astype(config.floatX)
+        ),
+        set_test_value(
+            aet.matrix(), np.random.normal(size=(2, 2)).astype(config.floatX)
+        ),
+    )
+    g = aetb.Join(view=1)(1, *vals)
+    g_fg = FunctionGraph(outputs=[g])
+
+    with pytest.raises(NotImplementedError):
+        compare_numba_and_py(
+            g_fg,
+            [
+                i.tag.test_value
+                for i in g_fg.inputs
+                if not isinstance(i, (SharedVariable, Constant))
+            ],
+        )


### PR DESCRIPTION
This PR implements Numba conversions for `CAReduce` `Op`s (i.e. this PR adds a type of `ufunc.reduce` support for our vectorized Numba functions).