### PR TITLE
Update `jax.jit` args

### DIFF
--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -492,7 +492,7 @@ def jax_funcify_Scan(op, **kwargs):
 
         def jax_inner_func(carry, x):
             inner_args = jax_args_to_inner_scan(op, carry, x)
-            inner_scan_outs = [fn(*inner_args) for fn in jax_aet_inner_func]
+            inner_scan_outs = list(jax_aet_inner_func(*inner_args))
             new_carry = inner_scan_outs_to_jax_outs(op, carry, inner_scan_outs)
             return new_carry, inner_scan_outs
 

--- a/aesara/link/jax/linker.py
+++ b/aesara/link/jax/linker.py
@@ -20,7 +20,7 @@ class JAXLinker(JITLinker):
         static_argnums = [
             n for n, i in enumerate(self.fgraph.inputs) if isinstance(i, Constant)
         ]
-        return jax.jit(fn, static_argnums)
+        return jax.jit(fn, static_argnums=static_argnums)
 
     def create_thunk_inputs(self, storage_map):
         from aesara.link.jax.dispatch import jax_typify


### PR DESCRIPTION
This PR updates our calls to `jax.jit` per recent JAX updates that make `static_argnums` a keyword-only argument.