### PR TITLE
Explicitly add gcc dll directory on Python 3.8+ on Windows

### DIFF
--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -286,6 +286,11 @@ def dlimport(fullpath, suffix=None):
     _logger.debug(f"module_name {module_name}")
 
     sys.path[0:0] = [workdir]  # insert workdir at beginning (temporarily)
+    # Explicitly add gcc dll directory on Python 3.8+ on Windows
+    if (sys.platform == "win32") & (hasattr(os, "add_dll_directory")):
+        gcc_path = shutil.which("gcc")
+        if gcc_path is not None:
+            os.add_dll_directory(os.path.dirname(gcc_path))
     global import_time
     try:
         importlib.invalidate_caches()


### PR DESCRIPTION
This PR addresses a change in how DLLs in Python 3.8+ on Windows are resolved (Non-Anaconda). DLL folders need to be explicitly specified/added.

This PR closes #407

There may be a better place for this chunk of code to be put, but this solves the errors for me.