### PR TITLE
Fixing a typo in a page heading

### DIFF
--- a/doc/extending/scan.txt
+++ b/doc/extending/scan.txt
@@ -1,6 +1,6 @@
 .. _scan_internals:
 
-Developper documentation for Scan
+Developer documentation for Scan
 +++++++++++++++++++++++++++++++++
 
 Context

--- a/doc/extending/scan.txt
+++ b/doc/extending/scan.txt
@@ -1,7 +1,7 @@
 .. _scan_internals:
 
 Developer documentation for Scan
-+++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++
 
 Context
 =======


### PR DESCRIPTION
Changed Developper -> Developer in scan documentation.
