### PR TITLE
Fix `lift_rv_shapes` when `size` is empty and parameters are broadcasted

### DIFF
--- a/aesara/tensor/random/op.py
+++ b/aesara/tensor/random/op.py
@@ -11,15 +11,14 @@ from aesara.graph.op import Op
 from aesara.misc.safe_asarray import _asarray
 from aesara.tensor.basic import (
     as_tensor_variable,
-    cast,
     constant,
     get_scalar_constant_value,
     get_vector_length,
 )
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.random.type import RandomStateType
-from aesara.tensor.random.utils import params_broadcast_shapes
-from aesara.tensor.type import TensorType, all_dtypes, int_dtypes
+from aesara.tensor.random.utils import normalize_size_param, params_broadcast_shapes
+from aesara.tensor.type import TensorType, all_dtypes
 from aesara.tensor.type_other import NoneConst
 
 
@@ -348,18 +347,7 @@ class RandomVariable(Op):
             `(rng_var, out_var)`.
 
         """
-        if size is None:
-            size = constant([], dtype="int64")
-        elif isinstance(size, int):
-            size = as_tensor_variable([size], ndim=1)
-        elif not isinstance(size, (np.ndarray, Variable, Sequence)):
-            raise TypeError(
-                "Parameter size must be None, an integer, or a sequence with integers."
-            )
-        else:
-            size = cast(as_tensor_variable(size, ndim=1), "int64")
-
-        assert size.dtype in int_dtypes
+        size = normalize_size_param(size)
 
         dist_params = tuple(
             as_tensor_variable(p) if not isinstance(p, Variable) else p

--- a/aesara/tensor/random/opt.py
+++ b/aesara/tensor/random/opt.py
@@ -58,14 +58,20 @@ def lift_rv_shapes(node):
 
     dist_params = broadcast_params(dist_params, node.op.ndims_params)
 
-    dist_params = [
-        broadcast_to(
-            p, (tuple(size) + tuple(p.shape)) if node.op.ndim_supp > 0 else size
-        )
-        for p in dist_params
-    ]
+    if get_vector_length(size) > 0:
+        dist_params = [
+            broadcast_to(
+                p, (tuple(size) + tuple(p.shape)) if node.op.ndim_supp > 0 else size
+            )
+            for p in dist_params
+        ]
 
-    return node.op.make_node(rng, None, dtype, *dist_params)
+    new_node = node.op.make_node(rng, None, dtype, *dist_params)
+
+    if config.compute_test_value != "off":
+        compute_test_value(new_node)
+
+    return new_node
 
 
 @local_optimizer([DimShuffle])

--- a/tests/tensor/random/test_opt.py
+++ b/tests/tensor/random/test_opt.py
@@ -105,6 +105,13 @@ def test_lift_rv_shapes():
         np.array([0.0, 1.0], dtype=config.floatX),
         np.array(5.0, dtype=config.floatX),
     ]
+    test_size = []
+    check_shape_lifted_rv(normal, test_params, test_size, rng)
+
+    test_params = [
+        np.array([0.0, 1.0], dtype=config.floatX),
+        np.array(5.0, dtype=config.floatX),
+    ]
     test_size = [3, 2]
     check_shape_lifted_rv(normal, test_params, test_size, rng)
 


### PR DESCRIPTION
This PR adds a fix for `lift_rv_shapes` when `size` is empty and parameters are broadcasted.