### PR TITLE
Misc. `aesara.tensor.random` updates

### DIFF
--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -519,8 +519,6 @@ def numba_funcify_CAReduce(op, node, **kwargs):
 
     scalar_op_identity = np.asarray(op.scalar_op.identity, dtype=np_acc_dtype)
 
-    acc_dtype = numba.np.numpy_support.from_dtype(np_acc_dtype)
-
     scalar_nfunc_spec = op.scalar_op.nfunc_spec
 
     # We construct a dummy `Apply` that has the minimum required number of
@@ -528,15 +526,15 @@ def numba_funcify_CAReduce(op, node, **kwargs):
     # with too few arguments.
     dummy_node = Apply(
         op,
-        [tensor(acc_dtype, [False]) for i in range(scalar_nfunc_spec[1])],
-        [tensor(acc_dtype, [False]) for o in range(scalar_nfunc_spec[2])],
+        [tensor(np_acc_dtype, [False]) for i in range(scalar_nfunc_spec[1])],
+        [tensor(np_acc_dtype, [False]) for o in range(scalar_nfunc_spec[2])],
     )
     elemwise_fn = numba_funcify_Elemwise(op, dummy_node, use_signature=True, **kwargs)
 
     input_name = get_name_for_object(node.inputs[0])
     ndim = node.inputs[0].ndim
     careduce_fn = create_multiaxis_reducer(
-        elemwise_fn, scalar_op_identity, axes, ndim, acc_dtype, input_name=input_name
+        elemwise_fn, scalar_op_identity, axes, ndim, np_acc_dtype, input_name=input_name
     )
 
     return numba.njit(careduce_fn)

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -332,8 +332,11 @@ class Scalar(CType):
     ndim = 0
 
     def __init__(self, dtype):
-        if dtype == "floatX":
+        if isinstance(dtype, str) and dtype == "floatX":
             dtype = config.floatX
+        else:
+            dtype = np.dtype(dtype).name
+
         self.dtype = dtype
         self.dtype_specs()  # error checking
 

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -253,3 +253,6 @@ from aesara.tensor.type import (
     zvector,
 )
 from aesara.tensor.type_other import *
+
+
+__all__ = ["random"]  # noqa: F405

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -923,18 +923,21 @@ _cast_mapping = {
 
 def cast(x, dtype):
     """Symbolically cast `x` to a Tensor of type `dtype`."""
-    if dtype == "floatX":
+
+    if isinstance(dtype, str) and dtype == "floatX":
         dtype = config.floatX
 
+    dtype_name = np.dtype(dtype).name
+
     _x = as_tensor_variable(x)
-    if _x.type.dtype == dtype:
+    if _x.type.dtype == dtype_name:
         return _x
-    if _x.type.dtype.startswith("complex") and not dtype.startswith("complex"):
+    if _x.type.dtype.startswith("complex") and not dtype_name.startswith("complex"):
         raise TypeError(
             "Casting from complex to real is ambiguous: consider real(), "
             "imag(), angle() or abs()"
         )
-    return _cast_mapping[dtype](x)
+    return _cast_mapping[dtype_name](x)
 
 
 ##########################

--- a/aesara/tensor/random/__init__.py
+++ b/aesara/tensor/random/__init__.py
@@ -1,3 +1,5 @@
 # Initialize `RandomVariable` optimizations
 import aesara.tensor.random.opt
 import aesara.tensor.random.utils
+from aesara.tensor.random.basic import *
+from aesara.tensor.random.utils import RandomStream

--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -693,3 +693,41 @@ class PermutationRV(RandomVariable):
 
 
 permutation = PermutationRV()
+
+
+__all__ = [
+    "permutation",
+    "choice",
+    "randint",
+    "categorical",
+    "multinomial",
+    "betabinom",
+    "nbinom",
+    "binomial",
+    "laplace",
+    "bernoulli",
+    "truncexpon",
+    "wald",
+    "invgamma",
+    "halfcauchy",
+    "cauchy",
+    "hypergeometric",
+    "geometric",
+    "poisson",
+    "dirichlet",
+    "multivariate_normal",
+    "vonmises",
+    "logistic",
+    "weibull",
+    "exponential",
+    "gumbel",
+    "pareto",
+    "chisquare",
+    "gamma",
+    "lognormal",
+    "halfnormal",
+    "normal",
+    "beta",
+    "triangular",
+    "uniform",
+]

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -75,9 +75,11 @@ class TensorType(CType):
     """
 
     def __init__(self, dtype, broadcastable, name=None):
-        self.dtype = str(dtype)
-        if self.dtype == "floatX":
+        if isinstance(dtype, str) and dtype == "floatX":
             self.dtype = config.floatX
+        else:
+            self.dtype = np.dtype(dtype).name
+
         # broadcastable is immutable, and all elements are either
         # True or False
         self.broadcastable = tuple(bool(b) for b in broadcastable)

--- a/tests/scalar/test_type.py
+++ b/tests/scalar/test_type.py
@@ -13,6 +13,11 @@ from aesara.scalar.basic import (
 )
 
 
+def test_numpy_dtype():
+    test_type = Scalar(np.int32)
+    assert test_type.dtype == "int32"
+
+
 def test_div_types():
     a = int8()
     b = int32()

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -6,10 +6,8 @@ from aesara import config
 from aesara.assert_op import Assert
 from aesara.gradient import NullTypeGradError, grad
 from aesara.tensor.math import eq
-from aesara.tensor.random.basic import normal
-from aesara.tensor.random.op import RandomVariable, default_shape_from_params, observed
-from aesara.tensor.type import all_dtypes, iscalar, tensor, vector
-from aesara.tensor.type_other import NoneTypeT
+from aesara.tensor.random.op import RandomVariable, default_shape_from_params
+from aesara.tensor.type import all_dtypes, iscalar, tensor
 
 
 @fixture(scope="module", autouse=True)
@@ -149,28 +147,3 @@ def test_RandomVariable_floatX():
 
     with config.change_flags(floatX=new_floatX):
         assert test_rv_op(0, 1).dtype == new_floatX
-
-
-def test_observed():
-    rv_var = normal(0, 1, size=3)
-    obs_var = observed(rv_var, np.array([0.2, 0.1, -2.4], dtype=config.floatX))
-
-    assert obs_var.owner.inputs[0] is rv_var
-
-    with raises(TypeError):
-        observed(rv_var, np.array([1, 2], dtype=int))
-
-    with raises(TypeError):
-        observed(rv_var, np.array([[1.0, 2.0]], dtype=rv_var.dtype))
-
-    obs_rv = observed(None, np.array([0.2, 0.1, -2.4], dtype=config.floatX))
-
-    assert isinstance(obs_rv.owner.inputs[0].type, NoneTypeT)
-
-    rv_val = vector()
-    rv_val.tag.test_value = np.array([0.2, 0.1, -2.4], dtype=config.floatX)
-
-    obs_var = observed(rv_var, rv_val)
-
-    with raises(NullTypeGradError):
-        grad(obs_var.sum(), [rv_val])

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -111,6 +111,8 @@ def test_RandomVariable_basics():
     with raises(NullTypeGradError):
         grad(rv_out, [rv_node.inputs[0]])
 
+
+def test_RandomVariable_bcast():
     rv = RandomVariable("normal", 0, [0, 0], config.floatX, inplace=True)
 
     mu = tensor(config.floatX, [True, False, False])
@@ -128,6 +130,10 @@ def test_RandomVariable_basics():
 
     res = rv.compute_bcast([mu, sd], (s1, s2, s3))
     assert res == [False] * 3
+
+    size = aet.as_tensor((1, 2, 3), dtype=np.int32).astype(np.int64)
+    res = rv.compute_bcast([mu, sd], size)
+    assert res == [True, False, False]
 
 
 def test_RandomVariable_floatX():

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -851,6 +851,12 @@ def test_identity():
 
 
 class TestCast:
+    def test_can_use_numpy_types(self):
+        x = vector(dtype=np.int32)
+        y = cast(x, np.int64)
+        f = function([x], y)
+        assert f(np.array([1, 2], dtype=np.int32)).dtype == np.int64
+
     def test_good_between_real_types(self):
         good = itertools.chain(
             multi_dtype_cast_checks((2,), dtypes=REAL_DTYPES),

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -8,6 +8,11 @@ from aesara.configdefaults import config
 from aesara.tensor.type import TensorType
 
 
+def test_numpy_dtype():
+    test_type = TensorType(np.int32, [])
+    assert test_type.dtype == "int32"
+
+
 def test_filter_variable():
     test_type = TensorType(config.floatX, [])
 


### PR DESCRIPTION
This PR provides multiple `aesara.tensor.random` updates (e.g. removes the unnecessary `Observed` `Op`, exposes `RandomVariable`s via `aesara.tensor.random`, etc.).  It also allows the use of `numpy.dtype` instances (e.g. `numpy.int64`) as `dtype` arguments during tensor and scalar construction, as well as `aesara.tensor.cast`.