### PR TITLE
Do not require `fgraph.clients` entries in `RandomVariable` rewrites

### DIFF
--- a/aesara/tensor/random/opt.py
+++ b/aesara/tensor/random/opt.py
@@ -119,7 +119,8 @@ def local_dimshuffle_rv_lift(fgraph, node):
     # If no one else is using the underlying `RandomVariable`, then we can
     # do this; otherwise, the graph would be internally inconsistent.
     if not all(
-        (n == node or isinstance(n.op, Shape)) for n, i in fgraph.clients[base_rv]
+        (n == node or isinstance(n.op, Shape))
+        for n, i in fgraph.clients.get(base_rv, ())
     ):
         return False
 
@@ -273,7 +274,8 @@ def local_subtensor_rv_lift(fgraph, node):
     # If no one else is using the underlying `RandomVariable`, then we can
     # do this; otherwise, the graph would be internally inconsistent.
     if not all(
-        (n == node or isinstance(n.op, Shape)) for n, i in fgraph.clients[base_rv]
+        (n == node or isinstance(n.op, Shape))
+        for n, i in fgraph.clients.get(base_rv, ())
     ):
         return False
 


### PR DESCRIPTION
This PR removes the requirement that `fgraph.clients` contain valid entries in the `local_dimshuffle_rv_lift` and `local_subtensor_rv_lift` rewrites.

With this change, those rewrites can be used without unnecessary restrictions on the `fgraph` argument, which&mdash;for example&mdash;allows them to be used with `aesara.graph.opt.pre_greedy_local_optimizer`.