### PR TITLE
[Part 2/N] Refactor 'import aesara' into explicit imports across the codebase

### DIFF
--- a/aesara/__init__.py
+++ b/aesara/__init__.py
@@ -103,7 +103,7 @@ if (
     or config.init_gpu_device.startswith("opencl")
     or config.contexts != ""
 ):
-    import aesara.gpuarray
+    from aesara import gpuarray
 
 
 def get_scalar_constant_value(v):

--- a/aesara/compile/debugmode.py
+++ b/aesara/compile/debugmode.py
@@ -18,11 +18,11 @@ from warnings import warn
 
 import numpy as np
 
-import aesara
 from aesara.compile.function.types import (
     Function,
     FunctionMaker,
     infer_reuse_pattern,
+    insert_deepcopy,
     std_fgraph,
 )
 from aesara.compile.mode import Mode, register_mode
@@ -36,6 +36,7 @@ from aesara.graph.op import COp, Op, ops_with_inner_function
 from aesara.graph.utils import MethodNotDefined
 from aesara.link.basic import Container, LocalLinker
 from aesara.link.utils import map_storage, raise_with_op
+from aesara.tensor import math
 from aesara.utils import NoDuplicateOptWarningFilter, difference, get_unbound_function
 
 
@@ -402,7 +403,7 @@ def str_diagnostic(expected, value, rtol, atol):
         print(ssio.getvalue(), file=sio)
     except Exception:
         pass
-    atol_, rtol_ = aesara.tensor.math._get_atol_rtol(expected, value)
+    atol_, rtol_ = math._get_atol_rtol(expected, value)
     if rtol is not None:
         rtol_ = rtol
     if atol is not None:
@@ -2441,7 +2442,7 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
             with config.change_flags(compute_test_value=config.compute_test_value_opt):
                 optimizer(fgraph)
 
-                aesara.compile.function.types.insert_deepcopy(
+                insert_deepcopy(
                     fgraph, inputs, list(chain(outputs, additional_outputs))
                 )
 

--- a/aesara/compile/function/__init__.py
+++ b/aesara/compile/function/__init__.py
@@ -77,9 +77,9 @@ def function_dump(
         on_unused_input=on_unused_input,
     )
     with open(filename, "wb") as f:
-        import aesara.misc.pkl_utils
+        from aesara.misc import pkl_utils
 
-        pickler = aesara.misc.pkl_utils.StripPickler(
+        pickler = pkl_utils.StripPickler(
             f, protocol=-1, extra_tag_to_remove=extra_tag_to_remove
         )
         pickler.dump(d)

--- a/aesara/compile/mode.py
+++ b/aesara/compile/mode.py
@@ -7,7 +7,6 @@ import logging
 import warnings
 from typing import Tuple, Union
 
-import aesara
 from aesara.compile.function.types import Supervisor
 from aesara.configdefaults import config
 from aesara.graph.destroyhandler import DestroyHandler
@@ -182,10 +181,10 @@ class PrintCurrentFunctionGraph(GlobalOptimizer):
         self.header = header
 
     def apply(self, fgraph):
-        import aesara.printing
+        from aesara import printing
 
         print("PrintCurrentFunctionGraph:", self.header)
-        aesara.printing.debugprint(fgraph.outputs)
+        printing.debugprint(fgraph.outputs)
 
 
 optdb = SequenceDB()
@@ -421,9 +420,7 @@ class Mode:
 # FunctionMaker, the Mode will be taken from this dictionary using the
 # string as the key
 # Use VM_linker to allow lazy evaluation by default.
-FAST_COMPILE = Mode(
-    aesara.link.vm.VMLinker(use_cloop=False, c_thunks=False), "fast_compile"
-)
+FAST_COMPILE = Mode(VMLinker(use_cloop=False, c_thunks=False), "fast_compile")
 if config.cxx:
     FAST_RUN = Mode("cvm", "fast_run")
 else:

--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -10,8 +10,6 @@ import textwrap
 
 import numpy as np
 
-import aesara
-import aesara.configparser
 from aesara.configparser import (
     BoolParam,
     ConfigParam,
@@ -21,6 +19,7 @@ from aesara.configparser import (
     FloatParam,
     IntParam,
     StrParam,
+    _config,
 )
 from aesara.utils import (
     LOCAL_BITWIDTH,
@@ -29,6 +28,7 @@ from aesara.utils import (
     maybe_add_to_os_environ_pathlist,
     output_subprocess_Popen,
 )
+from aesara.version import version as __version__
 
 
 _logger = logging.getLogger("aesara.configdefaults")
@@ -111,7 +111,7 @@ def _filter_mode(val):
     ]
     if val in str_options:
         return val
-    # This can be executed before Aesara is completly imported, so
+    # This can be executed before Aesara is completely imported, so
     # aesara.compile.mode.Mode is not always available.
     # Instead of isinstance(val, aesara.compile.mode.Mode),
     # we can inspect the __mro__ of the object!
@@ -1707,7 +1707,7 @@ _compiledir_format_dict = {
     "python_version": platform.python_version(),
     "python_bitwidth": LOCAL_BITWIDTH,
     "python_int_bitwidth": PYTHON_INT_BITWIDTH,
-    "aesara_version": aesara.__version__,
+    "aesara_version": __version__,
     "numpy_version": np.__version__,
     "gxx_version": "xxx",
     "hostname": socket.gethostname(),
@@ -1832,7 +1832,7 @@ SUPPORTED_DNN_CONV_PRECISION = (
 # `configparser.config` is flooded with deprecation warnings. These warnings
 # instruct one to use `aesara.config`, which is an alias for
 # `aesara.configdefaults.config`.
-config = aesara.configparser._config
+config = _config
 
 # The functions below register config variables into the config instance above.
 add_basic_configvars()

--- a/aesara/d3viz/formatting.py
+++ b/aesara/d3viz/formatting.py
@@ -7,11 +7,11 @@ from functools import reduce
 
 import numpy as np
 
-import aesara
 from aesara.compile import Function, builders
 from aesara.graph.basic import Apply, Constant, Variable, graph_inputs
 from aesara.graph.fg import FunctionGraph
 from aesara.printing import pydot_imported, pydot_imported_msg
+from aesara.tensor.sharedvar import TensorSharedVariable
 
 
 try:
@@ -175,7 +175,7 @@ class PyDotFormatter:
                     }
                     if isinstance(var, Constant):
                         vparams["node_type"] = "constant_input"
-                    elif isinstance(var, aesara.tensor.sharedvar.TensorSharedVariable):
+                    elif isinstance(var, TensorSharedVariable):
                         vparams["node_type"] = "shared_input"
                     vparams["dtype"] = type_to_str(var.type)
                     vparams["tag"] = var_tag(var)

--- a/tests/compile/function/test_types.py
+++ b/tests/compile/function/test_types.py
@@ -6,7 +6,6 @@ import time
 import numpy as np
 import pytest
 
-import aesara.gpuarray
 import aesara.tensor as aet
 from aesara.compile import shared
 from aesara.compile.debugmode import DebugMode, InvalidValueError
@@ -15,7 +14,7 @@ from aesara.compile.function.types import UnusedInputError
 from aesara.compile.io import In, Out
 from aesara.compile.mode import Mode, get_default_mode
 from aesara.configdefaults import config
-from aesara.gpuarray import gpuarray_shared_constructor
+from aesara.gpuarray import gpuarray_shared_constructor, pygpu_activated
 from aesara.gpuarray.blas import GpuGemm
 from aesara.graph.basic import Constant
 from aesara.graph.fg import MissingInputError
@@ -1151,7 +1150,7 @@ def test_empty_givens_updates():
 
 
 @pytest.mark.skipif(
-    not aesara.gpuarray.pygpu_activated or config.mode == "DEBUG_MODE",
+    not pygpu_activated or config.mode == "DEBUG_MODE",
     reason="DEBUG_MODE forces synchronous behaviour which breaks this test",
 )
 def test_sync_update():


### PR DESCRIPTION
Part 2/N of #235 

# Removal of circular dependencies in Aesara

Remove circular dependencies in the codebase by first starting to replace `import aesara ` with modular imports, such as the following:


```
import aesara

if aesara.config.xyz:
    # do something

class MyOp(aesara.Op):
    # ...
```


Ideally, we want:

```
from aesara.configdefaults import config
from aesara.gof.op import Op

if config.xyz:
    # do something

class MyOp(Op):
    # ...
```


## Tests

My pytest commands are the following

```
pytest tests/compile
pytest tests/d3viz
```