### PR TITLE
Fix Numba `DimShuffle` with non-array input

### DIFF
--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -926,7 +926,7 @@ def numba_funcify_DimShuffle(op, **kwargs):
     # E           shuffle_shape = res.shape[: len(shuffle)]
     @numba.njit
     def dimshuffle(x):
-        return dimshuffle_inner(x, shuffle)
+        return dimshuffle_inner(np.asarray(x), shuffle)
 
     return dimshuffle
 

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -602,13 +602,11 @@ def numba_funcify_CAReduce(op, node, **kwargs):
 
 @numba_funcify.register(Composite)
 def numba_funcify_Composite(op, node, **kwargs):
-    numba_impl = numba.njit(numba_funcify(op.fgraph, **kwargs))
-
-    @numba.njit
-    def composite(*args):
-        return numba_impl(*args)[0]
-
-    return composite
+    signature = create_numba_signature(node, force_scalar=True)
+    composite_fn = numba.njit(signature)(
+        numba_funcify(op.fgraph, squeeze_output=True, **kwargs)
+    )
+    return composite_fn
 
 
 def create_index_func(node, objmode=False):

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -378,7 +378,10 @@ def {scalar_op_fn_name}({input_names}):
 def numba_funcify_Switch(op, node, **kwargs):
     @numba.njit
     def switch(condition, x, y):
-        return x if np.all(condition) else y
+        if condition:
+            return x
+        else:
+            return y
 
     return switch
 

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -371,7 +371,9 @@ def {scalar_op_fn_name}({input_names}):
     """
     scalar_op_fn = compile_function_src(scalar_op_src, scalar_op_fn_name, global_env)
 
-    return numba.njit(scalar_op_fn)
+    signature = create_numba_signature(node, force_scalar=True)
+
+    return numba.njit(signature)(scalar_op_fn)
 
 
 @numba_funcify.register(Switch)

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -1,3 +1,4 @@
+import builtins
 import io
 import re
 import sys
@@ -595,7 +596,15 @@ def get_name_for_object(x: Any):
 
     if isinstance(x, Variable):
         name = re.sub("[^0-9a-zA-Z]+", "_", x.name) if x.name else ""
-        name = name if (name.isidentifier() and not iskeyword(name)) else x.auto_name
+        name = (
+            name
+            if (
+                name.isidentifier()
+                and not iskeyword(name)
+                and name not in dir(builtins)
+            )
+            else x.auto_name
+        )
     else:
         name = getattr(x, "__name__", None)
 

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -659,6 +659,7 @@ def fgraph_to_python(
     global_env: Optional[Dict[Any, Any]] = None,
     local_env: Optional[Dict[Any, Any]] = None,
     get_name_for_object: Callable[[Any], str] = get_name_for_object,
+    squeeze_output: bool = False,
     **kwargs,
 ) -> FunctionType:
     """Convert a ``FunctionGraph`` into a regular Python function.
@@ -694,6 +695,9 @@ def fgraph_to_python(
     get_name_for_object
         A function used to provide names for the objects referenced within the
         generated function.
+    squeeze_output
+        If the ``FunctionGraph`` has only one output and this option is
+        ``True``, return the single output instead of a tuple with the output.
     **kwargs
         The remaining keywords are passed to `python_conversion_fn`
     """
@@ -742,7 +746,9 @@ def fgraph_to_python(
     joined_body_assigns = indent("\n".join(body_assigns), "    ")
 
     if len(fgraph_output_names) == 1:
-        fgraph_return_src = f"({fgraph_output_names[0]},)"
+        fgraph_return_src = (
+            fgraph_output_names[0] if squeeze_output else f"({fgraph_output_names[0]},)"
+        )
     else:
         fgraph_return_src = ", ".join(fgraph_output_names)
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -302,6 +302,24 @@ def test_Elemwise(inputs, input_vals, output_fn):
     "inputs, input_values, scalar_fn",
     [
         (
+            [aet.scalar("x"), aet.scalar("y"), aet.scalar("z")],
+            [
+                np.array(10, dtype=config.floatX),
+                np.array(20, dtype=config.floatX),
+                np.array(30, dtype=config.floatX),
+            ],
+            lambda x, y, z: aes.add(x, y, z),
+        ),
+        (
+            [aet.scalar("x"), aet.scalar("y"), aet.scalar("z")],
+            [
+                np.array(10, dtype=config.floatX),
+                np.array(20, dtype=config.floatX),
+                np.array(30, dtype=config.floatX),
+            ],
+            lambda x, y, z: aes.mul(x, y, z),
+        ),
+        (
             [aet.scalar("x"), aet.scalar("y")],
             [
                 np.array(10, dtype=config.floatX),
@@ -312,9 +330,8 @@ def test_Elemwise(inputs, input_vals, output_fn):
     ],
 )
 def test_numba_Composite(inputs, input_values, scalar_fn):
-    x_s = aes.float64("x")
-    y_s = aes.float64("y")
-    comp_op = Elemwise(Composite([x_s, y_s], [scalar_fn(x_s, y_s)]))
+    composite_inputs = [aes.float64(i.name) for i in inputs]
+    comp_op = Elemwise(Composite(composite_inputs, [scalar_fn(*composite_inputs)]))
     out_fg = FunctionGraph(inputs, [comp_op(*inputs)])
     compare_numba_and_py(out_fg, input_values)
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -903,16 +903,27 @@ def test_ARange(start, stop, step, dtype):
 
 
 @pytest.mark.parametrize(
-    "careduce_fn, axis, v",
+    "careduce_fn, axis, v, keepdims",
     [
-        (aet.sum, 0, set_test_value(aet.vector(), np.arange(3, dtype=config.floatX))),
-        (aet.all, 0, set_test_value(aet.vector(), np.arange(3, dtype=config.floatX))),
+        (
+            aet.sum,
+            0,
+            set_test_value(aet.vector(), np.arange(3, dtype=config.floatX)),
+            False,
+        ),
+        (
+            aet.all,
+            0,
+            set_test_value(aet.vector(), np.arange(3, dtype=config.floatX)),
+            False,
+        ),
         (
             aet.sum,
             0,
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
         ),
         (
             aet.sum,
@@ -920,6 +931,7 @@ def test_ARange(start, stop, step, dtype):
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
         ),
         (
             aet.sum,
@@ -927,6 +939,7 @@ def test_ARange(start, stop, step, dtype):
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
         ),
         (
             aet.sum,
@@ -934,6 +947,7 @@ def test_ARange(start, stop, step, dtype):
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
         ),
         (
             aet.sum,
@@ -941,14 +955,21 @@ def test_ARange(start, stop, step, dtype):
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
         ),
-        (aet.prod, 0, set_test_value(aet.vector(), np.arange(3, dtype=config.floatX))),
+        (
+            aet.prod,
+            0,
+            set_test_value(aet.vector(), np.arange(3, dtype=config.floatX)),
+            False,
+        ),
         (
             aet.prod,
             0,
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
         ),
         (
             aet.prod,
@@ -956,11 +977,20 @@ def test_ARange(start, stop, step, dtype):
             set_test_value(
                 aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
             ),
+            False,
+        ),
+        (
+            aet.max,
+            None,
+            set_test_value(
+                aet.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+            True,
         ),
     ],
 )
-def test_CAReduce(careduce_fn, axis, v):
-    g = careduce_fn(v, axis=axis)
+def test_CAReduce(careduce_fn, axis, v, keepdims):
+    g = careduce_fn(v, axis=axis, keepdims=keepdims)
     g_fg = FunctionGraph(outputs=[g])
 
     compare_numba_and_py(

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -103,7 +103,7 @@ def eval_python_only(fn_inputs, fgraph, inputs):
             return x
 
     def njit_noop(*args, **kwargs):
-        if len(args) == 1:
+        if len(args) == 1 and callable(args[0]):
             return args[0]
         else:
             return lambda x: x
@@ -118,9 +118,9 @@ def eval_python_only(fn_inputs, fgraph, inputs):
             def inner_vec(*args):
                 if len(args) > nparams:
                     out = args[-1]
-                    out[:] = fn(*args[:nparams])
+                    out[:] = np.vectorize(fn)(*args[:nparams])
                 else:
-                    return fn(*args)
+                    return np.vectorize(fn)(*args)
 
             return inner_vec
 


### PR DESCRIPTION
This PR fixes an issue in the Numba implementation of `DimShuffle` when its input is not an array.